### PR TITLE
Parses kick message and automatically reconnects to the other server

### DIFF
--- a/MCP src/GuiConnectFailed.java
+++ b/MCP src/GuiConnectFailed.java
@@ -1,0 +1,58 @@
+package net.minecraft.src;
+
+import net.minecraft.src.GuiButton;
+import net.minecraft.src.GuiMainMenu;
+import net.minecraft.src.GuiScreen;
+import net.minecraft.src.StringTranslate;
+
+//BukkitContrib Start
+import net.minecraft.src.ReconnectManager;
+//BukkitContrib Start
+
+public class GuiConnectFailed extends GuiScreen {
+
+   private String errorMessage;
+   private String errorDetail;
+
+
+   public GuiConnectFailed(String var1, String var2, Object ... var3) {
+      StringTranslate var4 = StringTranslate.getInstance();
+      this.errorMessage = var4.translateKey(var1);
+      if(var3 != null) {
+         this.errorDetail = var4.translateKeyFormat(var2, var3);
+      } else {
+         this.errorDetail = var4.translateKey(var2);
+      }
+
+      //BukkitContrib Start
+      ReconnectManager.detectKick(var1, var2, var3);
+      //BukkitContrib End
+   }
+
+   public void updateScreen() {}
+
+   protected void keyTyped(char var1, int var2) {}
+
+   public void initGui() {
+      StringTranslate var1 = StringTranslate.getInstance();
+      this.controlList.clear();
+      this.controlList.add(new GuiButton(0, this.width / 2 - 100, this.height / 4 + 120 + 12, var1.translateKey("gui.toMenu")));
+   }
+
+   protected void actionPerformed(GuiButton var1) {
+      if(var1.id == 0) {
+         this.mc.displayGuiScreen(new GuiMainMenu());
+      }
+
+   }
+
+   public void drawScreen(int var1, int var2, float var3) {
+      this.drawDefaultBackground();
+      this.drawCenteredString(this.fontRenderer, this.errorMessage, this.width / 2, this.height / 2 - 50, 16777215);
+      this.drawCenteredString(this.fontRenderer, this.errorDetail, this.width / 2, this.height / 2 - 10, 16777215);
+      super.drawScreen(var1, var2, var3);
+      //BukkitContrib Start
+      ReconnectManager.teleport(this.mc);
+      //BukkitContrib End
+   }
+}

--- a/MCP src/ReconnectManager.java
+++ b/MCP src/ReconnectManager.java
@@ -1,0 +1,51 @@
+package net.minecraft.src;
+
+import java.util.List;
+import java.lang.String;
+import net.minecraft.client.Minecraft;
+
+public class ReconnectManager {
+  static String hostName = null;
+  static int portNum = -1;
+
+  static public void detectKick(String infoString, String reason,
+      Object[] objects) {
+    portNum = -1;
+
+    if (infoString == null || reason == null || objects == null) {
+      return;
+    }
+
+    if (objects.length == 0 || !(objects[0] instanceof String))
+      return;
+
+    reason = (String) objects[0];
+
+    if (infoString.contains("disconnect.disconnected")) {
+      if (reason.indexOf("[Serverport]") == 0
+          || reason.indexOf("[Redirect]") == 0) {
+        String[] split = reason.split(":");
+        if (split.length == 3) {
+          hostName = split[1].trim();
+          try {
+            portNum = Integer.parseInt(split[2].trim());
+          } catch (Exception e) {
+            portNum = -1;
+          }
+        } else if (split.length == 2) {
+          hostName = split[1].trim();
+          portNum = 25565;
+        }
+      }
+    }
+
+  }
+
+  static public void teleport(net.minecraft.client.Minecraft mc) {
+    if (portNum != -1 && hostName != null) {
+      mc.displayGuiScreen(new GuiConnecting(mc, hostName, portNum));
+    }
+  }
+
+}
+


### PR DESCRIPTION
This is pretty much the exact code that I use for patching the client to allow reconnects for ServerPort.

The main change is that both "[Redirect]" and "[Serverport]" can be used as the prefix in the kick message, instead of just "[Serverport]".  That was a request from the Transporter author, so he wouldn't have to hard-code Serverport into his code (which he did in the end, since I was to slow).

ReconnectManager handles the actual parsing of the kick message and also reconnecting.

2 hooks are added to GuiConnectFailed.  The one in the constructor parses the messages and stores the results and the one in drawScreen actually teleports.

This should be compatible with Transporter as well as ServerPort. 
