### PR TITLE
Server/Client matching packet lengths

### DIFF
--- a/MCP src/CustomPacket.java
+++ b/MCP src/CustomPacket.java
@@ -46,7 +46,7 @@ public class CustomPacket extends Packet{
 	 public void writePacketData(DataOutputStream output) throws IOException {
 		  //System.out.println("Writing Packet Data for " + packet.getPacketType());
 		  output.writeInt(packet.getPacketType().getId());
-		  output.writeInt(getPacketSize());
+		  output.writeInt(getPacketSize() - 8);
 		  packet.writeData(output);
 	 }
 


### PR DESCRIPTION
This matches the packet lengths for server and client.  

The server uses getNumBytes() via a(), which calls getNumBytes().  However, the client adds 8 to getNumBytes() and returns that as getPacketSize().

This may not be the cleanest fix.  Another option would be to change writePacketData() so that it calls getNumBytes() and leave getPacketSize() return the full packet size.
