### PR TITLE
Custom names can now be set for types that don't have subtypes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.classpath
 /.project
 /doc
+.DS_Store

--- a/MCP src/GuiContainer.java
+++ b/MCP src/GuiContainer.java
@@ -75,7 +75,7 @@ public abstract class GuiContainer extends GuiScreen {
 		if(var12.getItemStack() == null && var6 != null && var6.getHasStack()) {
 			String var13 = ("" + StringTranslate.getInstance().translateNamedKey(var6.getStack().getItemName())).trim();
 			//BukkitContrib Start
-			String custom = BukkitContrib.getItemManager().getCustomItemName(var6.getStack().itemID, var6.getStack().getItem().getHasSubtypes() ? (byte)(var6.getStack().getItemDamage()) : (byte)0);
+			String custom = BukkitContrib.getItemManager().getCustomItemName(var6.getStack().itemID, (byte)(var6.getStack().getItemDamage()));
 			if (custom != null) {
 				var13 = custom;
 			}


### PR DESCRIPTION
For example, an arrow with data=1 can now be called "Fire Arrow".
Also added Mac OS Files to .gitignore
