### PR TITLE
*Fast* packet listeners

### DIFF
--- a/src/org/bukkitcontrib/ContribNetServerHandler.java
+++ b/src/org/bukkitcontrib/ContribNetServerHandler.java
@@ -28,6 +28,7 @@ import org.bukkitcontrib.inventory.ContribCraftItemStack;
 import org.bukkitcontrib.inventory.ContribCraftingInventory;
 import org.bukkitcontrib.inventory.ContribInventory;
 import org.bukkitcontrib.inventory.CraftingInventory;
+import org.bukkitcontrib.packet.listener.Listeners;
 
 
 import net.minecraft.server.Container;
@@ -386,6 +387,8 @@ public class ContribNetServerHandler extends NetServerHandler{
 
 	@Override
 	public void sendPacket(Packet packet) {
+		if (!Listeners.canSend(packet))
+			return;
 		if(packet instanceof Packet51MapChunk) {
 			sendPacket((Packet51MapChunk)packet);
 		} else if(packet instanceof Packet50PreChunk) {

--- a/src/org/bukkitcontrib/packet/listener/Listener.java
+++ b/src/org/bukkitcontrib/packet/listener/Listener.java
@@ -1,0 +1,14 @@
+package org.bukkitcontrib.packet.listener;
+
+import net.minecraft.server.Packet;
+
+/**
+ * @author Nightgunner5
+ */
+public interface Listener {
+	/**
+	 * @param packet The packet to check
+	 * @return false if the packet should be stopped, true otherwise.
+	 */
+	public boolean checkPacket(Packet packet);
+}

--- a/src/org/bukkitcontrib/packet/listener/Listeners.java
+++ b/src/org/bukkitcontrib/packet/listener/Listeners.java
@@ -41,7 +41,7 @@ public class Listeners {
 	}
 
 	public static void addListener(int packetId, Listener listener) {
-		if (packetId > 255)
+		if (packetId < 0 || packetId > 255)
 			return;
 
 		lockWrite.lock();
@@ -54,7 +54,7 @@ public class Listeners {
 	}
 
 	public static boolean removeListener(int packetId, Listener listener) {
-		if (packetId > 255)
+		if (packetId < 0 || packetId > 255)
 			return false;
 
 		lockWrite.lock();
@@ -80,7 +80,7 @@ public class Listeners {
 	}
 
 	public static boolean hasListeners(int packetId) {
-		if (packetId > 255)
+		if (packetId < 0 || packetId > 255)
 			return false;
 
 		lockRead.lock();
@@ -105,7 +105,7 @@ public class Listeners {
 	}
 
 	public static boolean hasListener(int packetId, Listener listener) {
-		if (packetId > 255)
+		if (packetId < 0 || packetId > 255)
 			return false;
 
 		lockRead.lock();

--- a/src/org/bukkitcontrib/packet/listener/Listeners.java
+++ b/src/org/bukkitcontrib/packet/listener/Listeners.java
@@ -1,0 +1,87 @@
+package org.bukkitcontrib.packet.listener;
+
+import java.util.Arrays;
+
+import net.minecraft.server.Packet;
+
+/**
+ * Keeps track of packet listeners
+ * 
+ * @author Nightgunner5
+ */
+public class Listeners {
+	/**
+	 * Private constructor to avoid initialization
+	 */
+	private Listeners() {}
+
+	private static Listener[][] listeners = new Listener[256][0];
+
+	public static boolean canSend(Packet packet) {
+		for (Listener listener : listeners[packet.b()]) {
+			if (!listener.checkPacket(packet))
+				return false;
+		}
+		return true;
+	}
+
+	public static void addListener(int packetId, Listener listener) {
+		if (packetId >= listeners.length)
+			return;
+
+		listeners[packetId] = Arrays.copyOf(listeners[packetId], listeners[packetId].length + 1);
+		listeners[packetId][listeners[packetId].length - 1] = listener;
+	}
+
+	public static boolean removeListener(int packetId, Listener listener) {
+		if (packetId >= listeners.length)
+			return false;
+
+		int index = -1;
+		for (int i = 0; i < listeners[packetId].length; i++) {
+			if (listeners[packetId][i] == listener) {
+				index = i;
+				break;
+			}
+		}
+		if (index == -1)
+			return false;
+
+		Listener[] oldListeners = listeners[packetId];
+		listeners[packetId] = new Listener[oldListeners.length - 1];
+		System.arraycopy(oldListeners, 0, listeners[packetId], 0, index);
+		System.arraycopy(oldListeners, index + 1, listeners[packetId], index, oldListeners.length - 1 - index);
+
+		return true;
+	}
+
+	public static boolean hasListeners(int packetId) {
+		if (packetId >= listeners.length)
+			return false;
+
+		return listeners[packetId].length > 0;
+	}
+
+	public static boolean hasListeners() {
+		for (Listener[] packetListeners : listeners) {
+			if (packetListeners.length > 0)
+				return true;
+		}
+		return false;
+	}
+
+	public static boolean hasListener(int packetId, Listener listener) {
+		if (packetId >= listeners.length)
+			return false;
+
+		for (Listener packetListener : listeners[packetId]) {
+			if (packetListener == listener)
+				return true;
+		}
+		return false;
+	}
+
+	public static void clearAllListeners() {
+		listeners = new Listener[256][0];
+	}
+}

--- a/src/org/bukkitcontrib/packet/listener/Listeners.java
+++ b/src/org/bukkitcontrib/packet/listener/Listeners.java
@@ -1,6 +1,9 @@
 package org.bukkitcontrib.packet.listener;
 
 import java.util.Arrays;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import net.minecraft.server.Packet;
 
@@ -16,72 +19,113 @@ public class Listeners {
 	private Listeners() {}
 
 	private static Listener[][] listeners = new Listener[256][0];
+	private static final WriteLock lockWrite;
+	private static final ReadLock lockRead;
+	static {
+		ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+		lockWrite = lock.writeLock();
+		lockRead = lock.readLock();
+	}
 
 	public static boolean canSend(Packet packet) {
-		for (Listener listener : listeners[packet.b()]) {
-			if (!listener.checkPacket(packet))
-				return false;
+		lockRead.lock();
+		try {
+			for (Listener listener : listeners[packet.b()]) {
+				if (!listener.checkPacket(packet))
+					return false;
+			}
+			return true;
+		} finally {
+			lockRead.unlock();
 		}
-		return true;
 	}
 
 	public static void addListener(int packetId, Listener listener) {
-		if (packetId >= listeners.length)
+		if (packetId > 255)
 			return;
 
-		listeners[packetId] = Arrays.copyOf(listeners[packetId], listeners[packetId].length + 1);
-		listeners[packetId][listeners[packetId].length - 1] = listener;
+		lockWrite.lock();
+		try {
+			listeners[packetId] = Arrays.copyOf(listeners[packetId], listeners[packetId].length + 1);
+			listeners[packetId][listeners[packetId].length - 1] = listener;
+		} finally {
+			lockWrite.unlock();
+		}
 	}
 
 	public static boolean removeListener(int packetId, Listener listener) {
-		if (packetId >= listeners.length)
+		if (packetId > 255)
 			return false;
 
-		int index = -1;
-		for (int i = 0; i < listeners[packetId].length; i++) {
-			if (listeners[packetId][i] == listener) {
-				index = i;
-				break;
+		lockWrite.lock();
+		try {
+			int index = -1;
+			for (int i = 0; i < listeners[packetId].length; i++) {
+				if (listeners[packetId][i] == listener) {
+					index = i;
+					break;
+				}
 			}
+			if (index == -1)
+				return false;
+	
+			Listener[] oldListeners = listeners[packetId];
+			listeners[packetId] = new Listener[oldListeners.length - 1];
+			System.arraycopy(oldListeners, 0, listeners[packetId], 0, index);
+			System.arraycopy(oldListeners, index + 1, listeners[packetId], index, oldListeners.length - 1 - index);
+			return true;
+		} finally {
+			lockWrite.unlock();
 		}
-		if (index == -1)
-			return false;
-
-		Listener[] oldListeners = listeners[packetId];
-		listeners[packetId] = new Listener[oldListeners.length - 1];
-		System.arraycopy(oldListeners, 0, listeners[packetId], 0, index);
-		System.arraycopy(oldListeners, index + 1, listeners[packetId], index, oldListeners.length - 1 - index);
-
-		return true;
 	}
 
 	public static boolean hasListeners(int packetId) {
-		if (packetId >= listeners.length)
+		if (packetId > 255)
 			return false;
 
-		return listeners[packetId].length > 0;
+		lockRead.lock();
+		try {
+			return listeners[packetId].length > 0;
+		} finally {
+			lockRead.unlock();
+		}
 	}
 
 	public static boolean hasListeners() {
-		for (Listener[] packetListeners : listeners) {
-			if (packetListeners.length > 0)
-				return true;
+		lockRead.lock();
+		try {
+			for (Listener[] packetListeners : listeners) {
+				if (packetListeners.length > 0)
+					return true;
+			}
+			return false;
+		} finally {
+			lockRead.unlock();
 		}
-		return false;
 	}
 
 	public static boolean hasListener(int packetId, Listener listener) {
-		if (packetId >= listeners.length)
+		if (packetId > 255)
 			return false;
 
-		for (Listener packetListener : listeners[packetId]) {
-			if (packetListener == listener)
-				return true;
+		lockRead.lock();
+		try {
+			for (Listener packetListener : listeners[packetId]) {
+				if (packetListener == listener)
+					return true;
+			}
+			return false;
+		} finally {
+			lockRead.unlock();
 		}
-		return false;
 	}
 
 	public static void clearAllListeners() {
-		listeners = new Listener[256][0];
+		lockWrite.lock();
+		try {
+			listeners = new Listener[256][0];
+		} finally {
+			lockWrite.unlock();
+		}
 	}
 }


### PR DESCRIPTION
I'll write JavaDocs if you like it.

This way should be faster because it's not converting `int`s to `Integer` or doing `HashMap` lookups.
