### PR TITLE
Blank signs bug fix, doesn't compress chunks that are not in active chunk

### DIFF
--- a/src/org/bukkitcontrib/BukkitContrib.java
+++ b/src/org/bukkitcontrib/BukkitContrib.java
@@ -105,7 +105,9 @@ public class BukkitContrib extends JavaPlugin{
 		getServer().getPluginManager().registerEvent(Type.PLAYER_TELEPORT, playerListener, Priority.Monitor, this);
 		getServer().getPluginManager().registerEvent(Type.PLAYER_INTERACT, playerListener, Priority.Monitor, this);
 		getServer().getPluginManager().registerEvent(Type.PLAYER_COMMAND_PREPROCESS, playerListener, Priority.Monitor, this);
+		getServer().getPluginManager().registerEvent(Type.PLAYER_MOVE, playerListener, Priority.Normal, this);
 		getServer().getPluginManager().registerEvent(Type.CHUNK_LOAD, chunkListener, Priority.Lowest, this);
+		getServer().getPluginManager().registerEvent(Type.WORLD_LOAD, chunkListener, Priority.Lowest, this);
 		getServer().getPluginManager().registerEvent(Type.PLUGIN_DISABLE, pluginListener, Priority.Normal, this);
 
 		Player[] online = getServer().getOnlinePlayers();

--- a/src/org/bukkitcontrib/ContribChunkListener.java
+++ b/src/org/bukkitcontrib/ContribChunkListener.java
@@ -2,9 +2,12 @@ package org.bukkitcontrib;
 
 import java.lang.reflect.Field;
 
+import org.bukkit.craftbukkit.CraftWorld;
+
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.WorldListener;
 import org.bukkit.event.world.ChunkEvent;
+import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkitcontrib.block.ContribCraftChunk;
 
 public class ContribChunkListener extends WorldListener{
@@ -20,5 +23,11 @@ public class ContribChunkListener extends WorldListener{
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	@Override
+	public void onWorldLoad(WorldLoadEvent event) {
+		net.minecraft.server.World world = ((CraftWorld)event.getWorld()).getHandle();
+		ContribPlayerManager.replacePlayerManager((net.minecraft.server.WorldServer)world);
 	}
 }

--- a/src/org/bukkitcontrib/ContribPlayerInstance.java
+++ b/src/org/bukkitcontrib/ContribPlayerInstance.java
@@ -15,6 +15,8 @@ import net.minecraft.server.Packet50PreChunk;
 import net.minecraft.server.TileEntity;
 import net.minecraft.server.WorldServer;
 
+import org.bukkitcontrib.util.ReflectUtil;
+
 class ContribPlayerInstance {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -59,31 +61,18 @@ class ContribPlayerInstance {
 
 	public ContribPlayerInstance(ContribPlayerManager manager, Object instance) {
 		this(manager, 0, 0);
-		transferField(instance, this, "b");
-		transferField(instance, this, "chunkX");
-		transferField(instance, this, "chunkY");
-		transferField(instance, this, "location");
-		transferField(instance, this, "dirtyBlocks");
-		transferField(instance, this, "dirtyCount");
-		transferField(instance, this, "h");
-		transferField(instance, this, "i");
-		transferField(instance, this, "j");
-		transferField(instance, this, "k");
-		transferField(instance, this, "l");
-		transferField(instance, this, "m");
-	}
-
-	private static void transferField(Object src, Object dest, String fieldName) {
-		try {
-			Field field = src.getClass().getDeclaredField(fieldName);
-			field.setAccessible(true);
-			Object temp = field.get(src);
-			field.set(dest, temp);
-		} catch (NoSuchFieldException e) {
-			throw new RuntimeException(e);
-		} catch (IllegalAccessException e) {
-			throw new RuntimeException(e);
-		}
+		ReflectUtil.transferField(instance, this, "b");
+		ReflectUtil.transferField(instance, this, "chunkX");
+		ReflectUtil.transferField(instance, this, "chunkY");
+		ReflectUtil.transferField(instance, this, "location");
+		ReflectUtil.transferField(instance, this, "dirtyBlocks");
+		ReflectUtil.transferField(instance, this, "dirtyCount");
+		ReflectUtil.transferField(instance, this, "h");
+		ReflectUtil.transferField(instance, this, "i");
+		ReflectUtil.transferField(instance, this, "j");
+		ReflectUtil.transferField(instance, this, "k");
+		ReflectUtil.transferField(instance, this, "l");
+		ReflectUtil.transferField(instance, this, "m");
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/org/bukkitcontrib/ContribPlayerListener.java
+++ b/src/org/bukkitcontrib/ContribPlayerListener.java
@@ -3,6 +3,7 @@ package org.bukkitcontrib;
 import java.lang.reflect.Field;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Location;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -11,6 +12,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkitcontrib.event.bukkitcontrib.BukkitContribSPEnable;
 import org.bukkitcontrib.inventory.SimpleItemManager;
 import org.bukkitcontrib.player.ContribCraftPlayer;
@@ -104,4 +106,20 @@ public class ContribPlayerListener extends PlayerListener{
 			e.printStackTrace();
 		}
 	}
+
+	@Override
+	public void onPlayerMove(PlayerMoveEvent event) {
+
+		ContribCraftPlayer player = (ContribCraftPlayer)event.getPlayer();
+		ContribNetServerHandler netServerHandler = player.getNetServerHandler();
+
+		Location loc = event.getTo();
+
+		int cx = ((int)loc.getX()) >> 4;
+		int cz = ((int)loc.getZ()) >> 4;
+
+		netServerHandler.setPlayerChunk(cx, cz);
+
+	}
+
 }

--- a/src/org/bukkitcontrib/ContribPlayerManager.java
+++ b/src/org/bukkitcontrib/ContribPlayerManager.java
@@ -10,10 +10,12 @@ import java.lang.reflect.Method;
 
 import java.lang.reflect.InvocationTargetException;
 
+import org.bukkitcontrib.util.ReflectUtil;
+
 public class ContribPlayerManager extends net.minecraft.server.PlayerManager {
 
 	public static void replacePlayerManager(WorldServer world) {
-		if (!world.manager.getClass().equals(ContribPlayerManager.class.hashCode())) {
+		if (!world.manager.getClass().equals(ContribPlayerManager.class)) {
 			world.manager = new ContribPlayerManager(world.manager);
 			ContribPlayerInstance.replacePlayerInstances((ContribPlayerManager) world.manager);
 		}
@@ -23,29 +25,12 @@ public class ContribPlayerManager extends net.minecraft.server.PlayerManager {
 		super(null, 0, 10);
 		this.managedPlayers = manager.managedPlayers;
 		System.out.println("Tracking " + managedPlayers.size() + " players");
-		transferField(manager, this, "b");
-		transferField(manager, this, "c");
-		transferField(manager, this, "server");
-		transferField(manager, this, "e");
-		transferField(manager, this, "f");
-		transferField(manager, this, "g");
-	}
-
-	@SuppressWarnings( "rawtypes" )
-	private static void transferField(Object src, Object dest, String fieldName) {
-		try {
-			Class clazz = Class.forName("net.minecraft.server.PlayerManager");
-			Field field = clazz.getDeclaredField(fieldName);
-			field.setAccessible(true);
-			Object temp = field.get(src);
-			field.set(dest, temp);
-		} catch (NoSuchFieldException e) {
-			throw new RuntimeException(e);
-		} catch (IllegalAccessException e) {
-			throw new RuntimeException(e);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+		ReflectUtil.transferField(manager, this, "b");
+		ReflectUtil.transferField(manager, this, "c");
+		ReflectUtil.transferField(manager, this, "server");
+		ReflectUtil.transferField(manager, this, "e");
+		ReflectUtil.transferField(manager, this, "f");
+		ReflectUtil.transferField(manager, this, "g");
 	}
 
 	@SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/org/bukkitcontrib/util/ReflectUtil.java
+++ b/src/org/bukkitcontrib/util/ReflectUtil.java
@@ -1,0 +1,40 @@
+package org.bukkitcontrib.util;
+
+import java.lang.reflect.Field;
+
+public class ReflectUtil {
+	
+	public static void transferField(Object src, Object dest, String fieldName) {
+		try {
+			Field field = getField(src, fieldName);
+			field.setAccessible(true);
+			Object temp = field.get(src);
+			field = getField(dest, fieldName);
+			field.setAccessible(true);
+			field.set(dest, temp);
+		} catch (NoSuchFieldException e) {
+			throw new RuntimeException(e);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static Field getField(Object o, String fieldName) throws NoSuchFieldException {
+		return getField(o.getClass(), fieldName);
+	}
+
+	public static Field getField(Class clazz, String fieldName) throws NoSuchFieldException {
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+			return field;
+		} catch (NoSuchFieldException e) {
+			Class superclass = clazz.getSuperclass();
+			if(superclass == null) {
+				throw e;
+			} else {
+				return getField(superclass, fieldName);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Change list:
- (Our) Blank signs bug fix
- Doesn't compress chunks that are not active on the client
- Replaces worlds onLoad (so works if file is renamed zzzBukkitContrib.jar)
- Uses player move events to track player location (minecarts support)
- adds ReflectUtil class to handle field transfers

The minecarts things works in testing.  It generates a 5 chunk wide path for the minecart and doesn't send anything else.  I did get a client crash in the end, but I think there is something wrong with my setup.
