### PR TITLE
Changes packet listeners to atomic references for thread safety

### DIFF
--- a/src/org/bukkitcontrib/ContribNetServerHandler.java
+++ b/src/org/bukkitcontrib/ContribNetServerHandler.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
+import org.bukkit.entity.Player;
 import org.bukkitcontrib.event.inventory.InventoryClickEvent;
 import org.bukkitcontrib.event.inventory.InventoryCloseEvent;
 import org.bukkitcontrib.event.inventory.InventoryCraftEvent;
@@ -403,7 +404,7 @@ public class ContribNetServerHandler extends NetServerHandler{
 
 	// MapChunkThread sends packets to the method.  All packets should pass through this method before being sent to the client
 	public void sendPacket2(Packet packet) {
-		if (!Listeners.canSend(packet)) {
+		if (!Listeners.canSend((Player)player.getBukkitEntity(), packet)) {
 			return;
 		} else if(packet instanceof Packet51MapChunk) {
 			sendPacket2((Packet51MapChunk)packet);

--- a/src/org/bukkitcontrib/packet/listener/Listener.java
+++ b/src/org/bukkitcontrib/packet/listener/Listener.java
@@ -1,14 +1,16 @@
 package org.bukkitcontrib.packet.listener;
 
 import net.minecraft.server.Packet;
+import org.bukkit.entity.Player;
 
 /**
  * @author Nightgunner5
  */
 public interface Listener {
 	/**
+         * @param player The player the packet is sent to
 	 * @param packet The packet to check
 	 * @return false if the packet should be stopped, true otherwise.
 	 */
-	public boolean checkPacket(Packet packet);
+	public boolean checkPacket(Player player, Packet packet);
 }


### PR DESCRIPTION
This changes the packet listeners to use atomic references.  This should give thread safety will less of the sync overhead.

Also, the way this is implemented, listeners are assigned using something like:

```
Listeners.addListener(3, this);
```

There is no packet listener manager.

Also, it might be worth sending player information for the packet.  <b>This is added in the latest version</b>
