### PR TITLE
Changes where MapChunkThread is shutdown

### DIFF
--- a/src/org/bukkitcontrib/BukkitContrib.java
+++ b/src/org/bukkitcontrib/BukkitContrib.java
@@ -56,6 +56,7 @@ public class BukkitContrib extends JavaPlugin{
 		appearanceManager.onPluginDisable();
 		itemManager.reset();
 		skyManager.reset();
+		MapChunkThread.endThread(); // must happen before NetServerHandlers are converted back to standard
 		Player[] online = getServer().getOnlinePlayers();
 		for (Player player : online) {
 			try {
@@ -93,8 +94,6 @@ public class BukkitContrib extends JavaPlugin{
 		}
 		catch (Exception e) {}
 		
-		//end the thread
-		MapChunkThread.endThread();
 	}
 
 	@Override


### PR DESCRIPTION
Intermittent exceptions happen when reloading.

This is caused because the NetserverHandlers are switched back to normal before the MapChunkThread is shut down.

It attempts to call sendPacket2, but the method doesn't exist on normal NetServerHandlers.

This calls endThread before the netserverhandlers are switched back.  Since endThread has a .join() call, it guarantees that the MapChunkThread is shut down before the NetServerHandler replacements occur.
