### PR TITLE
Adds support for Packet51 listener prior to compression

### DIFF
--- a/src/org/bukkitcontrib/MapChunkThread.java
+++ b/src/org/bukkitcontrib/MapChunkThread.java
@@ -2,6 +2,10 @@
 
 package org.bukkitcontrib;
 
+import org.bukkitcontrib.packet.listener.Listeners;
+
+import org.bukkit.entity.Player;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -106,6 +110,10 @@ public final class MapChunkThread implements Runnable {
 	private void handle(QueuedPacket task) {
 		addToQueueSize(task.players, -1);
 		if (task.compress) {
+			Player p = task.players.length == 1 ? (Player)task.players[0].getBukkitEntity() : null;
+			if (!Listeners.canSendUncompressedPacket(p, task.packet)) {
+				return;
+			}
 			handleMapChunk(task);
 		}
 		sendToNetworkQueue(task);

--- a/src/org/bukkitcontrib/packet/listener/Listeners.java
+++ b/src/org/bukkitcontrib/packet/listener/Listeners.java
@@ -22,11 +22,21 @@ public class Listeners {
 	private final static AtomicReference[] listeners;
 
 	static {
-		listeners = new AtomicReference[256];
+		listeners = new AtomicReference[257];
 		for(int i = 0; i < listeners.length; i++) {
 			listeners[i] = new AtomicReference<Listener[]>();
 		}
 		clearAllListeners();
+	}
+
+	public static boolean canSendUncompressedPacket(Player player, Packet packet) {
+		AtomicReference<Listener[]> listenerReference = (AtomicReference<Listener[]>)listeners[256];
+		Listener[] listenerArray = listenerReference.get();
+		for (Listener listener : listenerArray) {
+			if (!listener.checkPacket(player, packet))
+				return false;
+		}
+		return true;
 	}
 
 	public static boolean canSend(Player player, Packet packet) {
@@ -39,8 +49,19 @@ public class Listeners {
 		return true;
 	}
 
+	public static void addListenerUncompressedChunk(Listener listener) {
+		addListener2(256, listener);
+	}
+
 	public static void addListener(int packetId, Listener listener) {
-		if (packetId < 0 || packetId > 255)
+		if (packetId > 255) {
+			return;
+		}
+		addListener2(packetId, listener);
+	}
+
+	private static void addListener2(int packetId, Listener listener) {
+		if (packetId < 0)
 			return;
 
 		AtomicReference<Listener[]> listenerReference = (AtomicReference<Listener[]>)listeners[packetId];
@@ -54,8 +75,19 @@ public class Listeners {
 		}
 	}
 
+	public static boolean removeListenerUncompressedChunk(Listener listener) {
+		return removeListener2(256, listener);
+	}
+
 	public static boolean removeListener(int packetId, Listener listener) {
-		if (packetId < 0 || packetId > 255)
+		if (packetId > 255) {
+			return false;
+		}
+		return removeListener2(packetId, listener);
+	}
+
+	private static boolean removeListener2(int packetId, Listener listener) {
+		if (packetId < 0)
 			return false;
 
 		AtomicReference<Listener[]> listenerReference = (AtomicReference<Listener[]>)listeners[packetId];
@@ -82,7 +114,7 @@ public class Listeners {
 	}
 
 	public static boolean hasListeners(int packetId) {
-		if (packetId < 0 || packetId > 255)
+		if (packetId < 0 || packetId > 256)
 			return false;
 
 		AtomicReference<Listener[]> listenerReference = (AtomicReference<Listener[]>)listeners[packetId];
@@ -92,7 +124,7 @@ public class Listeners {
 
 	public static boolean hasListeners() {
 		for(int i = 0; i < listeners.length; i++) {
-			if(hasListeners(i)) {
+			if (hasListeners(i)) {
 				return true;
 			}
 		}
@@ -100,7 +132,7 @@ public class Listeners {
 	}
 
 	public static boolean hasListener(int packetId, Listener listener) {
-		if (packetId < 0 || packetId > 255)
+		if (packetId < 0 || packetId > 256)
 			return false;
 
 		AtomicReference<Listener[]> listenerReference = (AtomicReference<Listener[]>)listeners[packetId];


### PR DESCRIPTION
This allows the uncompressed data to be modified.

This saves the need to decompress and then recompress Packet51 data.
