### PR TITLE
Double chest top/bottom detection

### DIFF
--- a/src/org/getspout/spout/block/SpoutCraftChest.java
+++ b/src/org/getspout/spout/block/SpoutCraftChest.java
@@ -59,7 +59,18 @@ public class SpoutCraftChest extends CraftChest implements SpoutChest{
 	public DoubleChestInventory getFullInventory() {
 		if (isDoubleChest()){
 			SpoutCraftChest other = (SpoutCraftChest)getOtherSide();
-			return new SpoutDoubleChestInventory(new InventoryLargeChest("Double Chest", chest, other.chest), getBlock(), other.getBlock());
+			SpoutCraftChest top, bottom;
+			
+			if ((this.getLocation().getBlockX() < other.getLocation().getBlockX()) ||
+				(this.getLocation().getBlockZ() < other.getLocation().getBlockZ())) {
+				top = this;
+				bottom = other;
+			} else {
+				top = other;
+				bottom = this;
+			}
+			
+			return new SpoutDoubleChestInventory(new InventoryLargeChest("Double Chest", top.chest, bottom.chest), top.getBlock(), bottom.getBlock());
 		}
 		return null;
 	}

--- a/src/org/getspout/spout/inventory/SpoutDoubleChestInventory.java
+++ b/src/org/getspout/spout/inventory/SpoutDoubleChestInventory.java
@@ -6,22 +6,22 @@ import org.bukkit.block.Block;
 import org.getspout.spoutapi.inventory.DoubleChestInventory;
 
 public class SpoutDoubleChestInventory extends SpoutCraftInventory implements DoubleChestInventory{
-	protected Block left;
-	protected Block right;
-	public SpoutDoubleChestInventory(IInventory inventory, Block left, Block right) {
+	protected Block top;
+	protected Block bottom;
+	public SpoutDoubleChestInventory(IInventory inventory, Block top, Block bottom) {
 		super(inventory);
-		this.left = left;
-		this.right = right;
+		this.top = top;
+		this.bottom = bottom;
 	}
 
 	@Override
-	public Block getLeftSide() {
-		return left;
+	public Block getTopHalf() {
+		return top;
 	}
 
 	@Override
-	public Block getRightSide() {
-		return right;
+	public Block getBottomHalf() {
+		return bottom;
 	}
 
 }

--- a/src/org/getspout/spout/inventory/SpoutDoubleChestInventory.java
+++ b/src/org/getspout/spout/inventory/SpoutDoubleChestInventory.java
@@ -3,6 +3,7 @@ package org.getspout.spout.inventory;
 import net.minecraft.server.IInventory;
 
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.getspout.spoutapi.inventory.DoubleChestInventory;
 
 public class SpoutDoubleChestInventory extends SpoutCraftInventory implements DoubleChestInventory{
@@ -22,6 +23,48 @@ public class SpoutDoubleChestInventory extends SpoutCraftInventory implements Do
 	@Override
 	public Block getBottomHalf() {
 		return bottom;
+	}
+	
+	@Override
+	public Block getLeftSide() {
+		if ((this.getDirection() == BlockFace.WEST) || (this.getDirection() == BlockFace.NORTH)) {
+			return top;
+		} else {
+			return bottom;
+		}
+	}
+
+	@Override
+	public Block getRightSide() {
+		if (this.getLeftSide().equals(top)) {
+			return bottom;
+		} else {
+			return top;
+		}
+	}
+	
+	@Override
+	public BlockFace getDirection() {
+		if (top.getLocation().getBlockX() == bottom.getLocation().getBlockX()) {
+			return this.isReversed(BlockFace.SOUTH) ? BlockFace.NORTH : BlockFace.SOUTH;
+		} else {
+			return this.isReversed(BlockFace.WEST) ? BlockFace.EAST : BlockFace.WEST;
+		}
+	}
+
+	private boolean isReversed(BlockFace primary) {
+		BlockFace secondary = primary.getOppositeFace();	
+		if (isSolid(top.getRelative(secondary)) || isSolid(bottom.getRelative(secondary))) {
+			return false;
+		} else {
+			return isSolid(top.getRelative(primary)) || isSolid(bottom.getRelative(primary));
+		}
+	}
+	
+	private static boolean isSolid(Block block) {
+		// o[]: If block type is non-solid.
+		// This should really be part of Spout or Bukkit, but for now it's here.
+		return net.minecraft.server.Block.o[block.getTypeId()];  
 	}
 
 }

--- a/src/org/getspout/spout/inventory/SpoutDoubleChestInventory.java
+++ b/src/org/getspout/spout/inventory/SpoutDoubleChestInventory.java
@@ -62,7 +62,7 @@ public class SpoutDoubleChestInventory extends SpoutCraftInventory implements Do
 	}
 	
 	private static boolean isSolid(Block block) {
-		// o[]: If block type is non-solid.
+		// o[]: If block type is completely solid.
 		// This should really be part of Spout or Bukkit, but for now it's here.
 		return net.minecraft.server.Block.o[block.getTypeId()];  
 	}


### PR DESCRIPTION
The left/right fields of double chests were arbitrarily defined by the block used to create the `DoubleChestInventory`. These commits resolve that by detecting which chests will be used to hold the top and bottom halves of the inventory.

A pull request to modify the function names in SpoutAPI is [here](https://github.com/SpoutDev/SpoutAPI/pull/5). Note that it's possible to detect which direction a double chest is facing, and thus which single chest is the left or right side, but this requires some way to determine whether a block is fully solid. Neither Bukkit nor Spout provide this, so the only way to get at it is `net.minecraft.server.Block.o[]`. If this can be resolved, I'll commit my code for detecting left/right chests and the original API functions can be used.

**EDIT 1:** I implemented the left/right detection, so the original API functions are still there. They behave differently of course, but since the prior behavior was so poorly defined, I doubt this will break many plugins.
