### PR TITLE
Biome Weather Hook + Player Info framework

### DIFF
--- a/src/org/getspout/spout/PlayerManager.java
+++ b/src/org/getspout/spout/PlayerManager.java
@@ -8,6 +8,7 @@ import org.getspout.spout.config.ConfigReader;
 import org.getspout.spout.inventory.SimpleItemManager;
 import org.getspout.spout.packet.CustomPacket;
 import org.getspout.spout.player.SimpleAppearanceManager;
+import org.getspout.spout.player.SimpleBiomeManager;
 import org.getspout.spout.player.SimpleSkyManager;
 import org.getspout.spout.player.SpoutCraftPlayer;
 import org.getspout.spoutapi.SpoutManager;
@@ -50,6 +51,7 @@ public class PlayerManager {
 		((SimpleAppearanceManager)SpoutManager.getAppearanceManager()).onPlayerJoin(player);
 		((SimpleItemManager)SpoutManager.getItemManager()).onPlayerJoin(player);
 		((SimpleSkyManager)SpoutManager.getSkyManager()).onPlayerJoin(player);
+		((SimpleBiomeManager)SpoutManager.getBiomeManager()).onPlayerJoin(player);
 		player.sendPacket(new PacketAllowVisualCheats(ConfigReader.isAllowVisualCheats()));
 		System.out.println("[Spout] Successfully authenticated " + player.getName() + "'s Spoutcraft client. Running client version: " + player.getVersion());
 		if(player.getVersion() > 101) {

--- a/src/org/getspout/spout/PlayerManager.java
+++ b/src/org/getspout/spout/PlayerManager.java
@@ -15,10 +15,12 @@ import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.event.spout.SpoutCraftEnableEvent;
 import org.getspout.spoutapi.packet.PacketAllowVisualCheats;
 import org.getspout.spoutapi.packet.PacketCacheHashUpdate;
+import org.getspout.spoutapi.player.PlayerInformation;
 import org.getspout.spoutapi.player.SpoutPlayer;
 
 public class PlayerManager {
 	private HashMap<String, Integer> timer = new HashMap<String, Integer>();
+	HashMap<String, PlayerInformation> infoMap = new HashMap<String, PlayerInformation>();
 	
 	public void onPlayerJoin(Player player){
 		timer.put(player.getName(), ConfigReader.getAuthenticateTicks());

--- a/src/org/getspout/spout/Spout.java
+++ b/src/org/getspout/spout/Spout.java
@@ -32,6 +32,7 @@ import org.getspout.spout.keyboard.SimpleKeyboardManager;
 import org.getspout.spout.packet.CustomPacket;
 import org.getspout.spout.packet.SimplePacketManager;
 import org.getspout.spout.player.SimpleAppearanceManager;
+import org.getspout.spout.player.SimpleBiomeManager;
 import org.getspout.spout.player.SimplePlayerManager;
 import org.getspout.spout.player.SimpleSkyManager;
 import org.getspout.spout.player.SpoutCraftPlayer;
@@ -63,6 +64,7 @@ public class Spout extends JavaPlugin{
 		SpoutManager.getInstance().setPlayerManager(new SimplePlayerManager());
 		SpoutManager.getInstance().setCacheManager(new SimpleCacheManager());
 		SpoutManager.getInstance().setChunkDataManager(new SimpleChunkDataManager());
+		SpoutManager.getInstance().setBiomeManager(new SimpleBiomeManager());
 	}
 	@Override
 	public void onDisable() {

--- a/src/org/getspout/spout/Spout.java
+++ b/src/org/getspout/spout/Spout.java
@@ -72,6 +72,7 @@ public class Spout extends JavaPlugin{
 		((SimpleAppearanceManager)SpoutManager.getAppearanceManager()).onPluginDisable();
 		((SimpleItemManager)SpoutManager.getItemManager()).reset();
 		((SimpleSkyManager)SpoutManager.getSkyManager()).reset();
+		((SimpleBiomeManager)SpoutManager.getBiomeManager()).reset();
 		Player[] online = getServer().getOnlinePlayers();
 		for (Player player : online) {
 			try {
@@ -156,6 +157,7 @@ public class Spout extends JavaPlugin{
 		
 		SpoutCraftChunk.replaceAllBukkitChunks();
 		((SimpleAppearanceManager)SpoutManager.getAppearanceManager()).onPluginEnable();
+		((SimpleBiomeManager)SpoutManager.getBiomeManager()).onPluginEnable();
 
 		MapChunkThread.startThread(); // Always on
 		

--- a/src/org/getspout/spout/Spout.java
+++ b/src/org/getspout/spout/Spout.java
@@ -72,7 +72,7 @@ public class Spout extends JavaPlugin{
 		((SimpleAppearanceManager)SpoutManager.getAppearanceManager()).onPluginDisable();
 		((SimpleItemManager)SpoutManager.getItemManager()).reset();
 		((SimpleSkyManager)SpoutManager.getSkyManager()).reset();
-		((SimpleBiomeManager)SpoutManager.getBiomeManager()).reset();
+		((SimplePlayerManager)SpoutManager.getPlayerManager()).onPluginDisable();
 		Player[] online = getServer().getOnlinePlayers();
 		for (Player player : online) {
 			try {
@@ -148,6 +148,7 @@ public class Spout extends JavaPlugin{
 			SpoutCraftPlayer.updateBukkitEntity(player);
 			authenticate(player);
 			playerListener.manager.onPlayerJoin(player);
+			((SimplePlayerManager)SpoutManager.getPlayerManager()).onPlayerJoin(player);
 		}
 
 		List<World> worlds = getServer().getWorlds();
@@ -157,7 +158,7 @@ public class Spout extends JavaPlugin{
 		
 		SpoutCraftChunk.replaceAllBukkitChunks();
 		((SimpleAppearanceManager)SpoutManager.getAppearanceManager()).onPluginEnable();
-		((SimpleBiomeManager)SpoutManager.getBiomeManager()).onPluginEnable();
+		((SimplePlayerManager)SpoutManager.getPlayerManager()).onPluginEnable();
 
 		MapChunkThread.startThread(); // Always on
 		

--- a/src/org/getspout/spout/SpoutPlayerListener.java
+++ b/src/org/getspout/spout/SpoutPlayerListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.getspout.spout.chunkcache.ChunkCache;
 import org.getspout.spout.player.SimpleAppearanceManager;
+import org.getspout.spout.player.SimplePlayerManager;
 import org.getspout.spout.player.SpoutCraftPlayer;
 import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.packet.PacketWorldSeed;
@@ -30,6 +31,7 @@ public class SpoutPlayerListener extends PlayerListener{
 		updatePlayerEvent(event);
 		Spout.getInstance().authenticate(event.getPlayer());
 		manager.onPlayerJoin(event.getPlayer());
+		((SimplePlayerManager)SpoutManager.getPlayerManager()).onPlayerJoin(event.getPlayer());
 	}
 
 	@Override

--- a/src/org/getspout/spout/player/SimpleBiomeManager.java
+++ b/src/org/getspout/spout/player/SimpleBiomeManager.java
@@ -1,7 +1,19 @@
 package org.getspout.spout.player;
 
+import org.bukkit.block.Biome;
+import org.getspout.spoutapi.packet.PacketBiomeWeather;
 import org.getspout.spoutapi.player.BiomeManager;
+import org.getspout.spoutapi.player.SpoutPlayer;
 
 public class SimpleBiomeManager implements BiomeManager{
+
+	@Override
+	public void setPlayerBiomeWeather(SpoutPlayer player, Biome biome, byte weather) {
+		if(player.isSpoutCraftEnabled()) {
+			byte biomeByte = (byte) biome.ordinal();
+			player.sendPacket(new PacketBiomeWeather(biomeByte,weather));
+		}
+		
+	}
 
 }

--- a/src/org/getspout/spout/player/SimpleBiomeManager.java
+++ b/src/org/getspout/spout/player/SimpleBiomeManager.java
@@ -9,109 +9,87 @@ import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.block.SpoutWeather;
 import org.getspout.spoutapi.packet.PacketBiomeWeather;
 import org.getspout.spoutapi.player.BiomeManager;
+import org.getspout.spoutapi.player.PlayerInformation;
 import org.getspout.spoutapi.player.SpoutPlayer;
 
-public class SimpleBiomeManager implements BiomeManager{
+public class SimpleBiomeManager implements BiomeManager {
 	
-	private final HashMap<String, HashMap<Biome, SpoutWeather>> weatherMap = new HashMap<String, HashMap<Biome, SpoutWeather>>();
+	HashMap<Biome, SpoutWeather> globalWeather = new HashMap<Biome, SpoutWeather>();
 
 	@Override
 	public void setPlayerBiomeWeather(SpoutPlayer player, Biome biome, SpoutWeather weather) {
-		if(!weatherMap.containsKey(player.getName())) {
-			weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
-			System.out.println("New Player");
+		PlayerInformation info = SpoutManager.getPlayerManager().getPlayerInfo(player);
+		info.setBiomeWeather(biome, weather);
+		if (player.isSpoutCraftEnabled()) {
+			player.sendPacket(new PacketBiomeWeather(biome, weather));
 		}
-		weatherMap.get(player.getName()).put(biome, weather);
-		if(player.isSpoutCraftEnabled()) {
-			byte biomeByte = (byte) biome.ordinal();
-			byte weatherByte = (byte) weather.ordinal();
-			player.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
-		}
-		
 	}
 
 	@Override
 	public void setPlayerWeather(SpoutPlayer player, SpoutWeather weather) {
-		if(!weatherMap.containsKey(player.getName())) {
-			weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
-		}
-		if(player.isSpoutCraftEnabled()) {
-			for(Biome biome : Biome.values()) {
-				weatherMap.get(player.getName()).put(biome, weather);
-				byte biomeByte = (byte) biome.ordinal();
-				byte weatherByte = (byte) weather.ordinal();
-				player.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+		PlayerInformation info = SpoutManager.getPlayerManager().getPlayerInfo(player);
+		for (Biome biome : Biome.values()) {
+			info.setBiomeWeather(biome, weather);
+			if (player.isSpoutCraftEnabled()) {
+				player.sendPacket(new PacketBiomeWeather(biome, weather));
 			}
 		}
-		
 	}
 
 	@Override
 	public void setGlobalBiomeWeather(Biome biome, SpoutWeather weather) {
-		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
-			if(!weatherMap.containsKey(player.getName())) {
-				weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
-			}
+		globalWeather.put(biome, weather);
+		
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
-			if(sPlayer.isSpoutCraftEnabled()) {
-				weatherMap.get(player.getName()).put(biome, weather);
-				byte biomeByte = (byte) biome.ordinal();
-				byte weatherByte = (byte) weather.ordinal();
-				sPlayer.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+			PlayerInformation info = SpoutManager.getPlayerManager().getPlayerInfo(player);
+			info.setBiomeWeather(biome, weather);
+			if (sPlayer.isSpoutCraftEnabled()) {
+				sPlayer.sendPacket(new PacketBiomeWeather(biome, weather));
 			}
 		}
-		
 	}
 
 	@Override
 	public void setGlobalWeather(SpoutWeather weather) {
-		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
-			if(!weatherMap.containsKey(player.getName())) {
-				weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
-			}
+		
+		for(Biome biome : Biome.values()) {
+			globalWeather.put(biome, weather);
+		}
+		
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
-			if(sPlayer.isSpoutCraftEnabled()) {
-				for(Biome biome : Biome.values()) {
-					weatherMap.get(player.getName()).put(biome, weather);
-					byte biomeByte = (byte) biome.ordinal();
-					byte weatherByte = (byte) weather.ordinal();
-					sPlayer.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+			PlayerInformation info = SpoutManager.getPlayerManager().getPlayerInfo(player);
+			for (Biome biome : Biome.values()) {
+				info.setBiomeWeather(biome, weather);
+				if (sPlayer.isSpoutCraftEnabled()) {
+					sPlayer.sendPacket(new PacketBiomeWeather(biome, weather));
 				}
 			}
 		}
-		
 	}
 
 	public void onPlayerJoin(SpoutPlayer player) {
-		if(player.isSpoutCraftEnabled()) {
-			if(weatherMap.containsKey(player.getName())) {
-				SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
-				for(Biome biome : weatherMap.get(player.getName()).keySet()) {
-					byte biomeByte = (byte) biome.ordinal();
-					byte weatherByte = (byte) weatherMap.get(player.getName()).get(biome).ordinal();
-					sPlayer.sendPacket(new PacketBiomeWeather(biomeByte, weatherByte));
-				}
+		PlayerInformation info = SpoutManager.getPlayerManager().getPlayerInfo(player);
+		
+		if(!globalWeather.isEmpty()) {
+			for(Biome biome : globalWeather.keySet()) {
+				info.setBiomeWeather(biome, globalWeather.get(biome));
+				player.sendPacket(new PacketBiomeWeather(biome, globalWeather.get(biome)));
 			}
 		}
+
 	}
-	
-	public void onPluginEnable() {
-		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
-			weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
-		}
+
+	@Override
+	public SpoutWeather getGlobalBiomeWeather(Biome biome) {
+		return globalWeather.get(biome);
 	}
-	
-	public void reset() {
-		weatherMap.clear();
-		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
-			SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
-			if(sPlayer.isSpoutCraftEnabled()) {
-				for(Biome biome : Biome.values()) {
-					byte biomeByte = (byte) biome.ordinal();
-					byte weatherByte = (byte) SpoutWeather.RESET.ordinal();
-					sPlayer.sendPacket(new PacketBiomeWeather(biomeByte, weatherByte));
-				}
-			}
-		}
+
+	@Override
+	public SpoutWeather getPlayerBiomeWeather(Player player, Biome biome) {
+		PlayerInformation info = SpoutManager.getPlayerManager().getPlayerInfo(player);
+		return info.getBiomeWeather(biome);
 	}
+
 }

--- a/src/org/getspout/spout/player/SimpleBiomeManager.java
+++ b/src/org/getspout/spout/player/SimpleBiomeManager.java
@@ -19,6 +19,7 @@ public class SimpleBiomeManager implements BiomeManager{
 	public void setPlayerBiomeWeather(SpoutPlayer player, Biome biome, SpoutWeather weather) {
 		if(!weatherMap.containsKey(player.getName())) {
 			weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
+			System.out.println("New Player");
 		}
 		weatherMap.get(player.getName()).put(biome, weather);
 		if(player.isSpoutCraftEnabled()) {
@@ -88,6 +89,26 @@ public class SimpleBiomeManager implements BiomeManager{
 				for(Biome biome : weatherMap.get(player.getName()).keySet()) {
 					byte biomeByte = (byte) biome.ordinal();
 					byte weatherByte = (byte) weatherMap.get(player.getName()).get(biome).ordinal();
+					sPlayer.sendPacket(new PacketBiomeWeather(biomeByte, weatherByte));
+				}
+			}
+		}
+	}
+	
+	public void onPluginEnable() {
+		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
+			weatherMap.put(player.getName(), new HashMap<Biome, SpoutWeather>());
+		}
+	}
+	
+	public void reset() {
+		weatherMap.clear();
+		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
+			SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
+			if(sPlayer.isSpoutCraftEnabled()) {
+				for(Biome biome : Biome.values()) {
+					byte biomeByte = (byte) biome.ordinal();
+					byte weatherByte = (byte) SpoutWeather.RESET.ordinal();
 					sPlayer.sendPacket(new PacketBiomeWeather(biomeByte, weatherByte));
 				}
 			}

--- a/src/org/getspout/spout/player/SimpleBiomeManager.java
+++ b/src/org/getspout/spout/player/SimpleBiomeManager.java
@@ -1,6 +1,10 @@
 package org.getspout.spout.player;
 
+import org.bukkit.Bukkit;
 import org.bukkit.block.Biome;
+import org.bukkit.entity.Player;
+import org.getspout.spoutapi.SpoutManager;
+import org.getspout.spoutapi.block.SpoutWeather;
 import org.getspout.spoutapi.packet.PacketBiomeWeather;
 import org.getspout.spoutapi.player.BiomeManager;
 import org.getspout.spoutapi.player.SpoutPlayer;
@@ -8,10 +12,51 @@ import org.getspout.spoutapi.player.SpoutPlayer;
 public class SimpleBiomeManager implements BiomeManager{
 
 	@Override
-	public void setPlayerBiomeWeather(SpoutPlayer player, Biome biome, byte weather) {
+	public void setPlayerBiomeWeather(SpoutPlayer player, Biome biome, SpoutWeather weather) {
 		if(player.isSpoutCraftEnabled()) {
 			byte biomeByte = (byte) biome.ordinal();
-			player.sendPacket(new PacketBiomeWeather(biomeByte,weather));
+			byte weatherByte = (byte) weather.ordinal();
+			player.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+		}
+		
+	}
+
+	@Override
+	public void setPlayerWeather(SpoutPlayer player, SpoutWeather weather) {
+		if(player.isSpoutCraftEnabled()) {
+			for(Biome biome : Biome.values()) {
+				byte biomeByte = (byte) biome.ordinal();
+				byte weatherByte = (byte) weather.ordinal();
+				player.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+			}
+		}
+		
+	}
+
+	@Override
+	public void setGlobalBiomeWeather(Biome biome, SpoutWeather weather) {
+		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
+			SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
+			if(sPlayer.isSpoutCraftEnabled()) {
+				byte biomeByte = (byte) biome.ordinal();
+				byte weatherByte = (byte) weather.ordinal();
+				sPlayer.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+			}
+		}
+		
+	}
+
+	@Override
+	public void setGlobalWeather(SpoutWeather weather) {
+		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
+			SpoutPlayer sPlayer = SpoutManager.getPlayer(player);
+			if(sPlayer.isSpoutCraftEnabled()) {
+				for(Biome biome : Biome.values()) {
+					byte biomeByte = (byte) biome.ordinal();
+					byte weatherByte = (byte) weather.ordinal();
+					sPlayer.sendPacket(new PacketBiomeWeather(biomeByte,weatherByte));
+				}
+			}
 		}
 		
 	}

--- a/src/org/getspout/spout/player/SimpleBiomeManager.java
+++ b/src/org/getspout/spout/player/SimpleBiomeManager.java
@@ -1,0 +1,7 @@
+package org.getspout.spout.player;
+
+import org.getspout.spoutapi.player.BiomeManager;
+
+public class SimpleBiomeManager implements BiomeManager{
+
+}

--- a/src/org/getspout/spout/player/SimplePlayerInformation.java
+++ b/src/org/getspout/spout/player/SimplePlayerInformation.java
@@ -1,0 +1,35 @@
+package org.getspout.spout.player;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import org.bukkit.block.Biome;
+import org.getspout.spoutapi.block.SpoutWeather;
+import org.getspout.spoutapi.player.PlayerInformation;
+
+public class SimplePlayerInformation implements PlayerInformation{
+	
+	HashMap<Biome,SpoutWeather> weatherMap = new HashMap<Biome, SpoutWeather>();
+
+	@Override
+	public SpoutWeather getBiomeWeather(Biome biome) {
+		if(weatherMap.containsKey(biome)) {
+			return weatherMap.get(biome);
+		}
+		else {
+			return SpoutWeather.RESET;
+		}
+	}
+
+	@Override
+	public void setBiomeWeather(Biome biome, SpoutWeather weather) {
+		weatherMap.put(biome, weather);
+	}
+
+	@Override
+	public Set<Biome> getBiomes() {
+		return weatherMap.keySet();
+	}
+
+
+}

--- a/src/org/getspout/spout/player/SimplePlayerManager.java
+++ b/src/org/getspout/spout/player/SimplePlayerManager.java
@@ -1,13 +1,17 @@
 package org.getspout.spout.player;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.getspout.spoutapi.player.PlayerInformation;
 import org.getspout.spoutapi.player.PlayerManager;
 import org.getspout.spoutapi.player.SpoutPlayer;
 
 public class SimplePlayerManager implements PlayerManager{
+	
+	HashMap<String, PlayerInformation> infoMap = new HashMap<String, PlayerInformation>();
 
 	@Override
 	public SpoutPlayer getPlayer(Player player) {
@@ -32,6 +36,25 @@ public class SimplePlayerManager implements PlayerManager{
 			}
 		}
 		return null;
+	}
+
+	@Override
+	public PlayerInformation getPlayerInfo(Player player) {
+		return infoMap.get(player.getName());
+	}
+	
+	public void onPlayerJoin(Player player) {
+		infoMap.put(player.getName(), new SimplePlayerInformation());
+	}
+	
+	public void onPluginEnable() {
+		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
+			infoMap.put(player.getName(), new SimplePlayerInformation());
+		}
+	}
+	
+	public void onPluginDisable() {
+		infoMap.clear();
 	}
 
 }

--- a/src/org/getspout/spout/player/SpoutCraftPlayer.java
+++ b/src/org/getspout/spout/player/SpoutCraftPlayer.java
@@ -38,6 +38,7 @@ import org.getspout.spout.inventory.SpoutCraftInventoryPlayer;
 import org.getspout.spout.inventory.SpoutCraftingInventory;
 import org.getspout.spout.packet.CustomPacket;
 import org.getspout.spout.packet.standard.MCCraftPacket;
+import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.event.inventory.InventoryCloseEvent;
 import org.getspout.spoutapi.event.inventory.InventoryOpenEvent;
 import org.getspout.spoutapi.gui.InGameScreen;
@@ -51,6 +52,7 @@ import org.getspout.spoutapi.packet.PacketRenderDistance;
 import org.getspout.spoutapi.packet.PacketTexturePack;
 import org.getspout.spoutapi.packet.SpoutPacket;
 import org.getspout.spoutapi.packet.standard.MCPacket;
+import org.getspout.spoutapi.player.PlayerInformation;
 import org.getspout.spoutapi.player.RenderDistance;
 import org.getspout.spoutapi.player.SpoutPlayer;
 
@@ -726,6 +728,11 @@ public class SpoutCraftPlayer extends CraftPlayer implements SpoutPlayer{
 			reconnect(split[0], port);
 		}
 		this.kickPlayer("[Redirect] Please reconnect to : " + hostname);
+	}
+
+	@Override
+	public PlayerInformation getInformation() {
+		return SpoutManager.getPlayerManager().getPlayerInfo(this);
 	}
 	
 }


### PR DESCRIPTION
Added a BiomeManager for setting weather per player per biome or globally, to force render of specific precipitations.

Added a framework for reworking how managers keep player information.
