### PR TITLE
BLOCK_PLACE callEvent implementation

### DIFF
--- a/src/org/getspout/spout/SpoutPlayerListener.java
+++ b/src/org/getspout/spout/SpoutPlayerListener.java
@@ -158,7 +158,6 @@ public class SpoutPlayerListener extends PlayerListener{
 							canBuild = true;
 						} else {
 							Location spawn = event.getClickedBlock().getWorld().getSpawnLocation();
-							//event.getPlayer().sendMessage(Math.max(block.getX()-spawn.getBlockX(), block.getZ()-spawn.getBlockZ()) + "/" + spawnRadius);
 							if (Math.max(Math.abs(block.getX()-spawn.getBlockX()), Math.abs(block.getZ()-spawn.getBlockZ())) > spawnRadius) { // Slower check
 								canBuild = true;
 							}

--- a/src/org/getspout/spout/SpoutPlayerListener.java
+++ b/src/org/getspout/spout/SpoutPlayerListener.java
@@ -22,8 +22,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -144,13 +146,38 @@ public class SpoutPlayerListener extends PlayerListener{
 					if (newBlockId != 0 ) {
 						Block block = event.getClickedBlock().getRelative(event.getBlockFace());
 						CustomBlock cb = MaterialData.getCustomBlock(damage);
+						BlockState oldState = block.getState();
 						block.setTypeIdAndData(cb.getBlockId(), (byte)(newMetaData & 0xF), true);
 						mm.overrideBlock(block, cb);
 						
-						if(item.getAmount() == 1) {
-							event.getPlayer().setItemInHand(null);
+						// TODO: canBuild should be set properly, CraftEventFactory.canBuild() would do this... 
+						//       but it's private so... here it is >.>
+						int spawnRadius = Bukkit.getServer().getSpawnRadius();
+						boolean canBuild = false;
+						if (spawnRadius <= 0 || player.isOp()) { // Fast checks
+							canBuild = true;
 						} else {
-							item.setAmount(item.getAmount() - 1);
+							Location spawn = event.getClickedBlock().getWorld().getSpawnLocation();
+							//event.getPlayer().sendMessage(Math.max(block.getX()-spawn.getBlockX(), block.getZ()-spawn.getBlockZ()) + "/" + spawnRadius);
+							if (Math.max(Math.abs(block.getX()-spawn.getBlockX()), Math.abs(block.getZ()-spawn.getBlockZ())) > spawnRadius) { // Slower check
+								canBuild = true;
+							}
+						}
+						
+						BlockPlaceEvent placeEvent = new BlockPlaceEvent(block, oldState, event.getClickedBlock(), item, player, canBuild);
+						Bukkit.getPluginManager().callEvent(placeEvent);
+						
+						if (!placeEvent.isCancelled() && placeEvent.canBuild()) {
+							// Yay, take the item from inventory
+							if(item.getAmount() == 1) {
+								event.getPlayer().setItemInHand(null);
+							} else {
+								item.setAmount(item.getAmount() - 1);
+							}
+						} else {
+							// Event cancelled or can't build
+							mm.removeBlockOverride(block);
+							block.setTypeIdAndData(oldState.getTypeId(), oldState.getRawData(), true);
 						}
 					}
 				}


### PR DESCRIPTION
This lets plugins catch custom block placements in the world, it also implements spawn protection for custom block placements

An example onBlockPlace for this is:

```
public void onBlockPlace(BlockPlaceEvent event) {
    if (event.isCancelled() || !event.canBuild()) return; // Don't do anything

    // This example shows the three levels of block types
    if(event.getBlock() instanceof SpoutBlock) {
        if (((SpoutBlock)event.getBlock()).isCustomBlock()) {
            // If you're using this, you'll probably be wanting this mostly, the "custom blocks"
            event.getPlayer().sendMessage("Placed CSB: " + ((SpoutBlock)event.getBlock()).getCustomBlock().getName());
        } else {
            // This is for blocks that Spout has extended with its own information
            event.getPlayer().sendMessage("Placed SB: " + ((SpoutBlock)event.getBlock()).getName());
        }
    } else {
        // And this is for regular old Bukkit type blocks if Spout isn't enabled
        event.getPlayer().sendMessage("Placed B: " + event.getBlockPlaced().getType());
    }
}
```
