### PR TITLE
Block break listener changed to Monitor

### DIFF
--- a/src/org/getspout/spout/Spout.java
+++ b/src/org/getspout/spout/Spout.java
@@ -207,7 +207,7 @@ public class Spout extends SpoutPlugin{
 		registerEvent(Type.WORLD_UNLOAD, chunkMonitorListener, Priority.Monitor);
 		registerEvent(Type.CHUNK_UNLOAD, chunkMonitorListener, Priority.Monitor);
 		registerEvent(Type.PLUGIN_DISABLE, pluginListener, Priority.Normal);
-		registerEvent(Type.BLOCK_BREAK, blockListener, Priority.Normal);
+		registerEvent(Type.BLOCK_BREAK, blockListener, Priority.Monitor);
 		registerEvent(Type.BLOCK_CANBUILD, blockListener, Priority.Lowest);
 		registerEvent(Type.ENTITY_TARGET, entityListener, Priority.Lowest);
 		registerEvent(Type.ENTITY_DAMAGE, entityListener, Priority.Lowest);


### PR DESCRIPTION
Currently custom blocks are not protected by antigriefing tools because the block listener is set to Normal. Swapping this to Monitor allows it to correctly know when the event was cancelled.
