### PR TITLE
Tool to remove ghosted custom blocks

### DIFF
--- a/src/org/getspout/spout/SpoutPlayerListener.java
+++ b/src/org/getspout/spout/SpoutPlayerListener.java
@@ -40,6 +40,7 @@ import org.getspout.spout.chunkcache.ChunkCache;
 import org.getspout.spout.inventory.SimpleMaterialManager;
 import org.getspout.spout.player.SimplePlayerManager;
 import org.getspout.spout.player.SpoutCraftPlayer;
+import org.getspout.spout.util.GhostBlock;
 import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.block.SpoutBlock;
 import org.getspout.spoutapi.event.inventory.InventoryCloseEvent;
@@ -108,6 +109,11 @@ public class SpoutPlayerListener extends PlayerListener{
 		if (event.isCancelled()) {
 			return;
 		}
+		if (GhostBlock.isRemoveGhostBlock()) {
+			GhostBlock.clearCustomBlock((SpoutBlock)event.getClickedBlock(), event.getPlayer());
+			return;
+		}
+	
 		if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
 			return;
 		}

--- a/src/org/getspout/spout/command/SpoutCommand.java
+++ b/src/org/getspout/spout/command/SpoutCommand.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.getspout.spout.Spout;
 import org.getspout.spout.config.ConfigReader;
 import org.getspout.spout.player.SpoutCraftPlayer;
+import org.getspout.spout.util.GhostBlock;
 import org.getspout.spoutapi.player.SpoutPlayer;
 
 public class SpoutCommand implements CommandExecutor {
@@ -39,6 +40,15 @@ public class SpoutCommand implements CommandExecutor {
 		if (c.equals("reload")) {
 			(new ConfigReader()).read();
 			sender.sendMessage("Configuration for Spout has been reloaded.");
+			return true;
+		}
+		if (c.equals("ghostblock")) {
+			GhostBlock.toggleGhostBlock();
+			if(GhostBlock.isRemoveGhostBlock()) { 
+				sender.sendMessage("Click the block which is showing a custom block texture incorrectly");
+			} else {
+				sender.sendMessage("Disabled Custom Block removal");
+			}
 			return true;
 		}
 		if (c.equals("version")) {

--- a/src/org/getspout/spout/util/GhostBlock.java
+++ b/src/org/getspout/spout/util/GhostBlock.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Spout (http://wiki.getspout.org/).
+ * 
+ * Spout is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spout is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.getspout.spout.util;
+
+import org.bukkit.entity.Player;
+import org.getspout.spout.inventory.SimpleMaterialManager;
+import org.getspout.spoutapi.SpoutManager;
+import org.getspout.spoutapi.block.SpoutBlock;
+
+public class GhostBlock {
+	private static boolean removenext = false;
+	
+	public static void clearCustomBlock(SpoutBlock block, Player player) {
+		if (block.isCustomBlock()) {
+			SimpleMaterialManager mm = (SimpleMaterialManager)SpoutManager.getMaterialManager();
+			mm.removeBlockOverride(block);
+			player.sendMessage("Custom Block was removed from coords: " + block.getX() + ", " + block.getY() + ", " + block.getZ() + " in world: " + block.getWorld().getName());
+		} else {
+			player.sendMessage("No custom block was found at that position");
+		}
+		toggleGhostBlock();
+	}
+	
+	public static void toggleGhostBlock() {
+		GhostBlock.removenext = !GhostBlock.removenext;
+	}
+	
+	public static boolean isRemoveGhostBlock() {
+		return removenext;
+	}
+}


### PR DESCRIPTION
On rare occasions a customblock will fail to be removed from the world. This means all future blocks at that location will be displayed in Spoutcraft as the custom block texture. This tool removes the override when you use "/spout ghostblock" and then hit the block in question.
