### PR TITLE
Fix up the pom and the start of proper tree generation routines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,17 @@
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.glowstone</groupId>
     <artifactId>glowstone</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Glowstone</name>
-    <url>https://github.com/SpaceManiac/Glowstone</url>
-    
+    <url>https://github.com/SpoutDev/Glowstone</url>
+
     <scm>
-        <connection>scm:git:git://github.com/SpaceManiac/Glowstone.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/SpaceManiac/Glowstone.git</developerConnection>
-        <url>https://github.com/SpaceManiac/Glowstone</url>
+        <connection>scm:git:git://github.com/SpoutDev/Glowstone.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/SpoutDev/Glowstone.git</developerConnection>
+        <url>https://github.com/SpoutDev/Glowstone</url>
     </scm>
 
     <properties>
@@ -23,7 +24,7 @@
             <id>bukkit</id>
             <name>Bukkit Artifactory</name>
             <layout>default</layout>
-            <url>http://repo.bukkit.org/content/groups/bukkit_repos/</url>
+            <url>http://repo.bukkit.org/content/groups/repo/</url>
         </repository>
         <repository>
             <id>jboss</id>
@@ -43,15 +44,24 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype OSS</name>
+            <layout>default</layout>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
-    
+
     <pluginRepositories>
         <pluginRepository>
             <id>bukkit-plugins</id>
             <url>http://repo.bukkit.org/content/repositories/plugins-release-local/</url>
         </pluginRepository>
     </pluginRepositories>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.bukkit</groupId>
@@ -102,12 +112,17 @@
         <dependency>
             <groupId>com.grahamedgecombe.jterminal</groupId>
             <artifactId>jterminal</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.getspout</groupId>
+            <artifactId>commons</artifactId>
+            <version>dev-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
     <build>
-        <defaultGoal>clean install</defaultGoal>
+        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>com.lukegb.mojo</groupId>
@@ -126,7 +141,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -137,7 +152,7 @@
                             <Main-Class>net.glowstone.GlowServer</Main-Class>
                             <Implementation-Title>${project.name}</Implementation-Title>
                             <Implementation-Version>${describe}</Implementation-Version>
-                            <Implementation-Vendor>SpaceManiac</Implementation-Vendor>
+                            <Implementation-Vendor>SpoutDev</Implementation-Vendor>
                             <Specification-Title>Bukkit</Specification-Title>
                             <Specification-Version>${bukkit.version}</Specification-Version>
                             <Specification-Vendor>Bukkit Team</Specification-Vendor>
@@ -154,14 +169,14 @@
                     </archive>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>1.4</version>
                 <executions>
-                <execution>
-                    <phase>package</phase>
+                    <execution>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -175,7 +190,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -223,5 +238,5 @@
             </plugin>
         </plugins>
     </build>
-    
+
 </project>

--- a/src/main/java/org/getspout/server/generator/populators/TreePopulator.java
+++ b/src/main/java/org/getspout/server/generator/populators/TreePopulator.java
@@ -2,13 +2,11 @@ package org.getspout.server.generator.populators;
 
 import java.util.Random;
 
-import static org.getspout.server.block.BlockID.LEAVES;
-
+import org.getspout.server.generator.populators.trees.GenericTreeGenerator;
+import org.getspout.server.generator.populators.trees.NormalTree;
 import org.bukkit.Chunk;
 import org.bukkit.World;
-import org.bukkit.block.Block;
 import org.bukkit.generator.BlockPopulator;
-import org.getspout.server.block.BlockID;
 
 /**
  * BlockPopulator that adds trees based on the biome.
@@ -56,6 +54,7 @@ public class TreePopulator extends BlockPopulator {
                 chance = 120;
                 break;
             case TAIGA:
+                // Redwood
                 chance = 120;
                 data = 1;
                 height = 8 + random.nextInt(3);
@@ -79,70 +78,11 @@ public class TreePopulator extends BlockPopulator {
             centerX = (source.getX() << 4) + random.nextInt(16);
             centerZ = (source.getZ() << 4) + random.nextInt(16);
             if (random.nextInt(300) < chance) {
-                int centerY = world.getHighestBlockYAt(centerX, centerZ) - 1;
-                Block sourceBlock = world.getBlockAt(centerX, centerY, centerZ);
-
-                if (sourceBlock.getTypeId() == BlockID.GRASS) {
-                    world.getBlockAt(centerX, centerY + height + 1, centerZ).setTypeIdAndData(LEAVES, data, true);
-                    for (int j = 0; j < 4; j++) {
-                        world.getBlockAt(centerX, centerY + height + 1 - j, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-                        world.getBlockAt(centerX, centerY + height + 1 - j, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                        world.getBlockAt(centerX - 1, centerY + height + 1 - j, centerZ).setTypeIdAndData(LEAVES, data, true);
-                        world.getBlockAt(centerX + 1, centerY + height + 1 - j, centerZ).setTypeIdAndData(LEAVES, data, true);
-                    }
-
-                    if (random.nextBoolean()) {
-                        world.getBlockAt(centerX + 1, centerY + height, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                    }
-                    if (random.nextBoolean()) {
-                        world.getBlockAt(centerX + 1, centerY + height, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-                    }
-                    if (random.nextBoolean()) {
-                        world.getBlockAt(centerX - 1, centerY + height, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                    }
-                    if (random.nextBoolean()) {
-                        world.getBlockAt(centerX - 1, centerY + height, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-                    }
-
-                    world.getBlockAt(centerX + 1, centerY + height - 1, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX + 1, centerY + height - 1, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX - 1, centerY + height - 1, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX - 1, centerY + height - 1, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX + 1, centerY + height - 2, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX + 1, centerY + height - 2, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX - 1, centerY + height - 2, centerZ + 1).setTypeIdAndData(LEAVES, data, true);
-                    world.getBlockAt(centerX - 1, centerY + height - 2, centerZ - 1).setTypeIdAndData(LEAVES, data, true);
-
-                    for (int j = 0; j < 2; j++) {
-                        for (int k = -2; k <= 2; k++) {
-                            for (int l = -2; l <= 2; l++) {
-                                world.getBlockAt(centerX + k, centerY + height - 1 - j, centerZ + l).setTypeIdAndData(LEAVES, data, true);
-                            }
-                        }
-                    }
-
-                    for (int j = 0; j < 2; j++) {
-                        if (random.nextBoolean()) {
-                            world.getBlockAt(centerX + 2, centerY + height - 1 - j, centerZ + 2).setTypeIdAndData(0, (byte) 0, true);
-                        }
-                        if (random.nextBoolean()) {
-                            world.getBlockAt(centerX + 2, centerY + height - 1 - j, centerZ - 2).setTypeIdAndData(0, (byte) 0, true);
-                        }
-                        if (random.nextBoolean()) {
-                            world.getBlockAt(centerX - 2, centerY + height - 1 - j, centerZ + 2).setTypeIdAndData(0, (byte) 0, true);
-                        }
-                        if (random.nextBoolean()) {
-                            world.getBlockAt(centerX - 2, centerY + height - 1 - j, centerZ - 2).setTypeIdAndData(0, (byte) 0, true);
-                        }
-                    }
-
-                    // Trunk
-                    for (int y = 1; y <= height; y++) {
-                        world.getBlockAt(centerX, centerY + y, centerZ).setTypeIdAndData(BlockID.LOG, data, true);
-                    }
+                if (data == 0) {
+                    GenericTreeGenerator treegen = new NormalTree();
+                    treegen.generate(random, centerX, centerZ, height, world);
                 }
             }
         }
     }
-    
 }

--- a/src/main/java/org/getspout/server/generator/populators/trees/GenericTreeGenerator.java
+++ b/src/main/java/org/getspout/server/generator/populators/trees/GenericTreeGenerator.java
@@ -1,0 +1,9 @@
+package org.getspout.server.generator.populators.trees;
+
+import java.util.Random;
+import org.bukkit.World;
+
+public interface GenericTreeGenerator {
+
+    public boolean generate(Random random, int centerX, int centerZ, int height, World world);
+}

--- a/src/main/java/org/getspout/server/generator/populators/trees/NormalTree.java
+++ b/src/main/java/org/getspout/server/generator/populators/trees/NormalTree.java
@@ -1,0 +1,104 @@
+package org.getspout.server.generator.populators.trees;
+
+import java.util.ArrayList;
+import java.util.Random;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+
+public class NormalTree implements GenericTreeGenerator {
+
+    @Override
+    public boolean generate(Random random, int centerX, int centerZ, int height, World world) {
+        ArrayList<BlockState> allBlocks = new ArrayList<BlockState>();
+        int centerY = world.getHighestBlockYAt(centerX, centerZ) - 1;
+        Block sourceBlock = world.getBlockAt(centerX, centerY, centerZ);
+
+        // TODO check for nearby trees
+
+       if (sourceBlock.getType() != Material.GRASS) {
+           return false;
+       }
+
+        BlockState dirtState = sourceBlock.getState();
+        dirtState.setType(Material.DIRT);
+        allBlocks.add(dirtState);
+
+        ArrayList<BlockState> leaves = new ArrayList<BlockState>();
+        leaves.add(world.getBlockAt(centerX, centerY + height + 1, centerZ).getState());
+
+        for (int j = 0; j < 4; j++) {
+            leaves.add(world.getBlockAt(centerX, centerY + height + 1 - j, centerZ - 1).getState());
+            leaves.add(world.getBlockAt(centerX, centerY + height + 1 - j, centerZ - 1).getState());
+            leaves.add(world.getBlockAt(centerX, centerY + height + 1 - j, centerZ + 1).getState());
+            leaves.add(world.getBlockAt(centerX - 1, centerY + height + 1 - j, centerZ).getState());
+            leaves.add(world.getBlockAt(centerX + 1, centerY + height + 1 - j, centerZ).getState());
+        }
+        if (random.nextBoolean()) {
+            leaves.add(world.getBlockAt(centerX + 1, centerY + height, centerZ + 1).getState());
+        }
+        if (random.nextBoolean()) {
+            leaves.add(world.getBlockAt(centerX + 1, centerY + height, centerZ - 1).getState());
+        }
+        if (random.nextBoolean()) {
+            leaves.add(world.getBlockAt(centerX - 1, centerY + height, centerZ + 1).getState());
+        }
+        if (random.nextBoolean()) {
+            leaves.add(world.getBlockAt(centerX - 1, centerY + height, centerZ - 1).getState());
+        }
+        leaves.add(world.getBlockAt(centerX + 1, centerY + height - 1, centerZ + 1).getState());
+        leaves.add(world.getBlockAt(centerX + 1, centerY + height - 1, centerZ - 1).getState());
+        leaves.add(world.getBlockAt(centerX - 1, centerY + height - 1, centerZ + 1).getState());
+        leaves.add(world.getBlockAt(centerX - 1, centerY + height - 1, centerZ - 1).getState());
+        leaves.add(world.getBlockAt(centerX + 1, centerY + height - 2, centerZ + 1).getState());
+        leaves.add(world.getBlockAt(centerX + 1, centerY + height - 2, centerZ - 1).getState());
+        leaves.add(world.getBlockAt(centerX - 1, centerY + height - 2, centerZ + 1).getState());
+        leaves.add(world.getBlockAt(centerX - 1, centerY + height - 2, centerZ - 1).getState());
+        for (int j = 0; j < 2; j++) {
+            for (int k = -2; k <= 2; k++) {
+                for (int l = -2; l <= 2; l++) {
+                    leaves.add(world.getBlockAt(centerX + k, centerY + height - 1 - j, centerZ + l).getState());
+                }
+            }
+        }
+        for (BlockState block : leaves) {
+            block.setType(Material.LEAVES);
+        }
+        allBlocks.addAll(leaves);
+
+        ArrayList<BlockState> air = new ArrayList<BlockState>();
+        for (int j = 0; j < 2; j++) {
+            if (random.nextBoolean()) {
+                air.add(world.getBlockAt(centerX + 2, centerY + height - 1 - j, centerZ + 2).getState());
+            }
+            if (random.nextBoolean()) {
+                air.add(world.getBlockAt(centerX + 2, centerY + height - 1 - j, centerZ - 2).getState());
+            }
+            if (random.nextBoolean()) {
+                air.add(world.getBlockAt(centerX - 2, centerY + height - 1 - j, centerZ + 2).getState());
+            }
+            if (random.nextBoolean()) {
+                air.add(world.getBlockAt(centerX - 2, centerY + height - 1 - j, centerZ - 2).getState());
+            }
+        }
+        for (BlockState block : air) {
+            block.setType(Material.AIR);
+        }
+        allBlocks.addAll(air);
+
+        ArrayList<BlockState> log = new ArrayList<BlockState>();
+        for (int y = 1; y <= height; y++) {
+            log.add(world.getBlockAt(centerX, centerY + y, centerZ).getState());
+        }
+        for (BlockState block : log) {
+            block.setType(Material.LOG);
+        }
+        allBlocks.addAll(log);
+        // TODO event
+        for (BlockState block : allBlocks){
+            world.getBlockAt(block.getX(), block.getY(), block.getZ()).setType(block.getType());
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/getspout/server/generator/populators/trees/NormalTree.java
+++ b/src/main/java/org/getspout/server/generator/populators/trees/NormalTree.java
@@ -2,10 +2,10 @@ package org.getspout.server.generator.populators.trees;
 
 import java.util.ArrayList;
 import java.util.Random;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.getspout.server.block.BlockID;
 
 public class NormalTree implements GenericTreeGenerator {
 
@@ -17,12 +17,12 @@ public class NormalTree implements GenericTreeGenerator {
 
         // TODO check for nearby trees
 
-       if (sourceBlock.getType() != Material.GRASS) {
+       if (sourceBlock.getTypeId() != BlockID.GRASS) {
            return false;
        }
 
         BlockState dirtState = sourceBlock.getState();
-        dirtState.setType(Material.DIRT);
+        dirtState.setTypeId(BlockID.DIRT);
         allBlocks.add(dirtState);
 
         ArrayList<BlockState> leaves = new ArrayList<BlockState>();
@@ -63,7 +63,7 @@ public class NormalTree implements GenericTreeGenerator {
             }
         }
         for (BlockState block : leaves) {
-            block.setType(Material.LEAVES);
+            block.setTypeId(BlockID.LEAVES);
         }
         allBlocks.addAll(leaves);
 
@@ -83,7 +83,7 @@ public class NormalTree implements GenericTreeGenerator {
             }
         }
         for (BlockState block : air) {
-            block.setType(Material.AIR);
+            block.setTypeId(BlockID.GRASS);
         }
         allBlocks.addAll(air);
 
@@ -92,7 +92,7 @@ public class NormalTree implements GenericTreeGenerator {
             log.add(world.getBlockAt(centerX, centerY + y, centerZ).getState());
         }
         for (BlockState block : log) {
-            block.setType(Material.LOG);
+            block.setTypeId(BlockID.LOG);
         }
         allBlocks.addAll(log);
         // TODO event


### PR DESCRIPTION
The name says it all. Refactors the pom to spoutdev, automatic downloading of jterminal. The treegens become more like notch code, with a separate generator for each type. Ive just added normal for the moment. It has workaround until we know what to do with events and blockstates. All details for the treegrow event is stored in an arraylist of blockstates and instead of calling the blockbuster.update it just manually loops through and sets them all.
