### PR TITLE
Added /teleport and /kill command

### DIFF
--- a/src/main/java/org/getspout/server/SpoutServer.java
+++ b/src/main/java/org/getspout/server/SpoutServer.java
@@ -467,6 +467,7 @@ public final class SpoutServer implements Server {
 		commandMap.register(new ToggleStormCommand(this));
 		commandMap.register(new TellCommand(this));
 		commandMap.register(new ExperienceCommand(this));
+		commandMap.register(new TeleportCommand(this));
 
 		enablePlugins(PluginLoadOrder.STARTUP);
 

--- a/src/main/java/org/getspout/server/SpoutServer.java
+++ b/src/main/java/org/getspout/server/SpoutServer.java
@@ -60,6 +60,7 @@ import org.getspout.server.command.ColorCommand;
 import org.getspout.server.command.DeopCommand;
 import org.getspout.server.command.ExperienceCommand;
 import org.getspout.server.command.GameModeCommand;
+import org.getspout.server.command.KillCommand;
 import org.getspout.server.command.SpoutCommandMap;
 import org.getspout.server.command.HelpCommand;
 import org.getspout.server.command.KickCommand;
@@ -70,6 +71,7 @@ import org.getspout.server.command.ReloadCommand;
 import org.getspout.server.command.SaveCommand;
 import org.getspout.server.command.SayCommand;
 import org.getspout.server.command.StopCommand;
+import org.getspout.server.command.TeleportCommand;
 import org.getspout.server.command.TellCommand;
 import org.getspout.server.command.TimeCommand;
 import org.getspout.server.command.ToggleStormCommand;
@@ -468,6 +470,7 @@ public final class SpoutServer implements Server {
 		commandMap.register(new TellCommand(this));
 		commandMap.register(new ExperienceCommand(this));
 		commandMap.register(new TeleportCommand(this));
+		commandMap.register(new KillCommand(this));
 
 		enablePlugins(PluginLoadOrder.STARTUP);
 

--- a/src/main/java/org/getspout/server/command/KillCommand.java
+++ b/src/main/java/org/getspout/server/command/KillCommand.java
@@ -24,7 +24,7 @@ public class KillCommand extends SpoutCommand{
 
 	@Override
 	public PermissionDefault getPermissionDefault() {
-		return PermissionDefault.OP;
+		return PermissionDefault.TRUE;
 	}
 
 }

--- a/src/main/java/org/getspout/server/command/KillCommand.java
+++ b/src/main/java/org/getspout/server/command/KillCommand.java
@@ -1,0 +1,30 @@
+package org.getspout.server.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionDefault;
+import org.getspout.server.SpoutServer;
+
+public class KillCommand extends SpoutCommand{
+
+	public KillCommand(SpoutServer server) {
+		super(server, "kill", "Gives the player a damage of 1000", "");
+	}
+
+	@Override
+	public boolean run(CommandSender sender, String commandLabel, String[] args) {
+		if(!(sender instanceof Player)) {
+			sender.sendMessage("You need to be a player to do this command.");
+			return false;
+		}
+		Player player = (Player) sender;
+		player.damage(1000);
+		return true;
+	}
+
+	@Override
+	public PermissionDefault getPermissionDefault() {
+		return PermissionDefault.OP;
+	}
+
+}

--- a/src/main/java/org/getspout/server/command/TeleportCommand.java
+++ b/src/main/java/org/getspout/server/command/TeleportCommand.java
@@ -1,0 +1,47 @@
+package org.getspout.server.command;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.permissions.PermissionDefault;
+import org.getspout.server.SpoutServer;
+
+public class TeleportCommand extends SpoutCommand{
+
+	public TeleportCommand(SpoutServer server) {
+		super(server, "teleport", "Teleport players to each other", "[playerfrom] [playerto]", "tp", "tele");
+	}
+
+	@Override
+	public boolean run(CommandSender sender, String commandLabel, String[] args) {
+		Player player1 = null;
+		Player player2 = null;
+		if(args.length<2) {
+			if(!(sender instanceof Player)) {
+				sender.sendMessage(ChatColor.RED + "You must be a player to use this without a player name");
+				return false;
+			}
+			player1 = (Player) sender;
+			player2 = server.getPlayerExact(args[0]);
+		}
+		else {
+			player1 = server.getPlayerExact(args[0]);
+			player2 = server.getPlayerExact(args[1]);
+		}
+		if(player1.teleport(player2, TeleportCause.COMMAND)) {
+			sender.sendMessage(player1.getName() + " has been succesfully teleported to " + player2.getName() + ".");
+			return true;
+		}
+		else {
+			sender.sendMessage(ChatColor.RED + "Unable to teleport player.");
+		}
+		return false;
+	}
+
+	@Override
+	public PermissionDefault getPermissionDefault() {
+		return PermissionDefault.OP;
+	}
+
+}

--- a/src/main/java/org/getspout/server/command/TeleportCommand.java
+++ b/src/main/java/org/getspout/server/command/TeleportCommand.java
@@ -15,11 +15,15 @@ public class TeleportCommand extends SpoutCommand{
 
 	@Override
 	public boolean run(CommandSender sender, String commandLabel, String[] args) {
+		if(args.length<1) {
+			sender.sendMessage(ChatColor.GRAY + "This command needs atleast 1 argument.");
+			return false;
+		}
 		Player player1 = null;
 		Player player2 = null;
 		if(args.length<2) {
 			if(!(sender instanceof Player)) {
-				sender.sendMessage(ChatColor.RED + "You must be a player to use this without a player name");
+				sender.sendMessage(ChatColor.GRAY + "You must be a player to use this command without a player name.");
 				return false;
 			}
 			player1 = (Player) sender;
@@ -29,12 +33,25 @@ public class TeleportCommand extends SpoutCommand{
 			player1 = server.getPlayerExact(args[0]);
 			player2 = server.getPlayerExact(args[1]);
 		}
+		
+		if(player1==null) {
+			sender.sendMessage(ChatColor.GRAY + "Cannot find user " + args[0] + ". No teleport.");
+			return false;
+		}
+		else if(player2==null) {
+			String playername = "UNDEFINED";
+			if(args.length<2) playername = args[0];
+			else if(args.length>=2) playername = args[1];
+			sender.sendMessage(ChatColor.GRAY + "Cannot find user " + playername + ". No teleport.");
+			return false;
+		}
+		
 		if(player1.teleport(player2, TeleportCause.COMMAND)) {
-			sender.sendMessage(player1.getName() + " has been succesfully teleported to " + player2.getName() + ".");
+			server.broadcastMessage(ChatColor.GRAY + "(" + sender.getName() + ": Teleporting " + player1.getName() + " to " + player2.getName() + ".");
 			return true;
 		}
 		else {
-			sender.sendMessage(ChatColor.RED + "Unable to teleport player.");
+			sender.sendMessage(ChatColor.GRAY + "Unable to teleport " + player1.getName() + " to " + player2.getName() + ".");
 		}
 		return false;
 	}


### PR DESCRIPTION
Added vanilla teleport (alias: tp, tele) command to Spout.
/tp playerfrom playerto
or /tp playerto (if you run it from a client).

Both can be ran in the client, but only the first one in console.

Added vanilla kill command to Spout.
/kill

Only client, only OP.

The SpoutServer.java commit got screwed up :P

/me going to bed now :D
