### PR TITLE
Added /teleport command. Allow custom kick message in stop command.

### DIFF
--- a/src/main/java/org/getspout/server/SpoutServer.java
+++ b/src/main/java/org/getspout/server/SpoutServer.java
@@ -499,9 +499,11 @@ public final class SpoutServer implements Server {
 	}
 
 	/**
-	 * Stops this server.
+	 * Stops this server with a given kick message.
+	 * 
+	 * @param message The message to display as kick message.
 	 */
-	public void shutdown() {
+	public void shutdown(String message) {
 		// This is so we don't run this twice (/stop and actual shutdown)
 		if (isShuttingDown) {
 			return;
@@ -517,7 +519,7 @@ public final class SpoutServer implements Server {
 
 		// Kick (and save) all players
 		for (Player player : getOnlinePlayers()) {
-			player.kickPlayer("Server shutting down.");
+			player.kickPlayer(message);
 		}
 
 		// Save worlds
@@ -533,6 +535,13 @@ public final class SpoutServer implements Server {
 		// And finally kill the console
 		consoleManager.stop();
 
+	}
+	
+	/**
+	 * Stops this server with the default kick message.
+	 */
+	public void shutdown() {
+		shutdown("Server shutting down.");
 	}
 
 	/**

--- a/src/main/java/org/getspout/server/SpoutServer.java
+++ b/src/main/java/org/getspout/server/SpoutServer.java
@@ -70,6 +70,7 @@ import org.getspout.server.command.SaveCommand;
 import org.getspout.server.command.SayCommand;
 import org.getspout.server.command.SpoutCommandMap;
 import org.getspout.server.command.StopCommand;
+import org.getspout.server.command.TeleportCommand;
 import org.getspout.server.command.TellCommand;
 import org.getspout.server.command.TimeCommand;
 import org.getspout.server.command.ToggleStormCommand;
@@ -477,6 +478,7 @@ public final class SpoutServer implements Server {
 		commandMap.register(new ToggleStormCommand(this));
 		commandMap.register(new TellCommand(this));
 		commandMap.register(new ExperienceCommand(this));
+		commandMap.register(new TeleportCommand(this));
 
 		enablePlugins(PluginLoadOrder.STARTUP);
 

--- a/src/main/java/org/getspout/server/command/StopCommand.java
+++ b/src/main/java/org/getspout/server/command/StopCommand.java
@@ -10,17 +10,24 @@ import org.getspout.server.SpoutServer;
  */
 public class StopCommand extends SpoutCommand {
 	public StopCommand(SpoutServer server) {
-		super(server, "stop", "Stops the server", "");
+		super(server, "stop", "Stops the server", "[message]");
 	}
 
 	@Override
 	public boolean run(CommandSender sender, String commandLabel, String[] args) {
-		if (!checkArgs(sender, args, 0)) {
-			return false;
-		} else {
-			server.shutdown();
-			return tellOps(sender, "Stopping the server");
+		if(args.length>0) {
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < args.length; i++) {
+				if(i!=0) sb.append(" ");
+			    sb.append(args[i]);
+			}
+			String message = sb.toString();
+			server.shutdown(message);
 		}
+		else {
+			server.shutdown();
+		}
+		return tellOps(sender, "Stopping the server");
 	}
 
 	@Override

--- a/src/main/java/org/getspout/server/command/TeleportCommand.java
+++ b/src/main/java/org/getspout/server/command/TeleportCommand.java
@@ -1,0 +1,59 @@
+package org.getspout.server.command;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionDefault;
+import org.getspout.server.SpoutServer;
+
+public class TeleportCommand extends SpoutCommand{
+
+	public TeleportCommand(SpoutServer server) {
+		super(server, "teleport", "Teleport players to each other.", "<playerfrom> [playerto]", "tp");
+	}
+
+	@Override
+	public boolean run(CommandSender sender, String commandLabel, String[] args) {
+		if(!checkArgs(sender, args, 1, 2)) {
+			return false;
+		}
+		String sfrom;
+		String sto;
+		if(args.length<2) {
+			if(!(sender instanceof Player)) {
+				sender.sendMessage(ChatColor.RED + "You must be a player to use this without a player name.");
+				return false;
+			}
+			sfrom = sender.getName();
+			sto = args[0];
+		}
+		else {
+			sfrom = args[0];
+			sto = args[1];
+		}
+		Player from = server.getPlayerExact(sfrom);
+		Player to = server.getPlayerExact(sto);
+		if(from==null) {
+			sender.sendMessage(ChatColor.GRAY + "Cannot find user " + sfrom + ". No teleport.");
+			return false;
+		}
+		else if(to==null) {
+			sender.sendMessage(ChatColor.GRAY + "Cannot find user " + sto + ". No teleport.");
+			return false;
+		}
+		if(from.teleport(to)) {
+			sender.sendMessage(ChatColor.GRAY + "(" + sender.getName() + ": Teleporting " + sfrom + " to " + sto + ".");
+			return true;
+		}
+		else {
+			sender.sendMessage(ChatColor.GRAY + "Unable to teleport.");
+		}
+		return false;
+	}
+
+	@Override
+	public PermissionDefault getPermissionDefault() {
+		return PermissionDefault.OP;
+	}
+
+}


### PR DESCRIPTION
This time without a screwed up commit :D

Added /teleport (alias: tp) command:
- Usage:
  /tp <playerfrom> <playerto>
  /tp <playerto> // Only from client.

Wrong number of arguments => blocked.

/shutdown [message]
All information in commit message :P
Tested (on commit 13e2c3ceff4a95b9b1ed163424670a27b5c5d512) and works, ofcourse.
