### PR TITLE
Fixed the SpoutServer to start the StorageQueue.

### DIFF
--- a/src/main/java/org/spout/server/SpoutServer.java
+++ b/src/main/java/org/spout/server/SpoutServer.java
@@ -289,6 +289,10 @@ public class SpoutServer extends AsyncManager implements Server {
 		consoleManager.setupConsole();
 
 		config.load();
+		
+		storeQueue.start(); //Make sure the storageQueue is running
+		banManager = new FlatFileBanManager(this); //Load the BanManager after the init of the Queue
+		banManager.load();
 
 		// Start loading plugins
 		loadPlugins();


### PR DESCRIPTION
Fixes throwing of exceptions at the start of the server.

StorageQueue always throws: "Cannot queue tasks while thread is not running"
because it was never started.

Signed-off-by: steffen steffenb198@aol.com
