### PR TITLE
Added transform update when pitch, roll and yaw are set in SpoutEntity

### DIFF
--- a/src/main/java/org/spout/engine/entity/SpoutEntity.java
+++ b/src/main/java/org/spout/engine/entity/SpoutEntity.java
@@ -141,9 +141,7 @@ public class SpoutEntity implements Entity {
 		if (controller != null && controller.getParent() != null && !isDead()) {
 			controller.onTick(dt);
 		}
-		this.rotate(roll, 1, 0, 0);
-		this.rotate(yaw, 0, 1, 0);
-		this.rotate(pitch, 0, 0, 1);
+		updateTransformAxisAngles();
 
 		if (controllerLive.get() instanceof PlayerController) {
 			Player player = ((PlayerController) controllerLive.get()).getPlayer();
@@ -325,7 +323,7 @@ public class SpoutEntity implements Entity {
 			}
 			return;
 		}
-		roll += ang;
+		setRoll(getRoll()+ang);
 	}
 
 	@Override
@@ -336,7 +334,7 @@ public class SpoutEntity implements Entity {
 			}
 			return;
 		}
-		pitch += ang;
+		setPitch(getPitch()+ang);
 	}
 
 	@Override
@@ -347,7 +345,7 @@ public class SpoutEntity implements Entity {
 			}
 			return;
 		}
-		yaw += ang;
+		setYaw(getYaw()+yaw);
 	}
 
 	@Override
@@ -374,6 +372,7 @@ public class SpoutEntity implements Entity {
 			return;
 		}
 		pitch = ang;
+		updateTransformAxisAngles();
 	}
 
 	@Override
@@ -385,6 +384,7 @@ public class SpoutEntity implements Entity {
 			return;
 		}
 		roll = ang;
+		updateTransformAxisAngles();
 	}
 
 	@Override
@@ -396,6 +396,7 @@ public class SpoutEntity implements Entity {
 			return;
 		}
 		yaw = ang;
+		updateTransformAxisAngles();
 	}
 
 	@Override
@@ -789,5 +790,12 @@ public class SpoutEntity implements Entity {
 	@Override
 	public boolean hasComponent(EntityComponent component) {
 		return components.contains(component);
+	}
+	
+	private void updateTransformAxisAngles() {
+		setRotation(Quaternion.IDENTITY);
+		rotate(pitch, 0,0,1);
+		rotate(yaw, 0,1,0);
+		rotate(roll, 1,0,0);
 	}
 }


### PR DESCRIPTION
Without this patch, pitch,roll and yaw of a SpoutEntity are constantly 0.0. This due to the transform never being updated when these values are set. I've also added a call to setRotation(Quaternion.IDENTITY) as it needs to reset before the values are reapplied :)

Signed-off-by: Victor Danell victor.danell@gmail.com
