### PR TITLE
setBlockController now create an entity if needed

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -832,7 +832,11 @@ public class SpoutRegion extends Region {
 
 	@Override
 	public void setBlockController(int x, int y, int z, BlockController controller) {
-		blockControllers.put(new Vector3(x, y, z), controller);
+		if (controller.getParent() == null) {
+			this.getWorld().createAndSpawnEntity(new Point(this.getWorld(), x, y, z), controller);
+		} else {
+			blockControllers.put(new Vector3(x, y, z), controller);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: berger killer bergerkiller@gmail.com

If a block controller is being set that not yet has an entity attached, it will first create and spawn the entity on the world.
