### PR TITLE
SPOUT-47: Correct chunk coordinate processing for unloadChunk and saveChunk

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutWorld.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorld.java
@@ -658,12 +658,18 @@ public class SpoutWorld extends AsyncManager implements World {
 
 	@Override
 	public void saveChunk(int x, int y, int z) {
-		this.getRegionFromBlock(x, y, z).saveChunk(x, y, z);
+		SpoutRegion r = this.getRegion(x >> Region.REGION_SIZE_BITS, y >> Region.REGION_SIZE_BITS, z >> Region.REGION_SIZE_BITS, false);
+		if (r != null) {
+			r.saveChunk(x & Region.REGION_SIZE - 1, y & Region.REGION_SIZE - 1, z & Region.REGION_SIZE - 1);
+		}
 	}
 
 	@Override
 	public void unloadChunk(int x, int y, int z, boolean save) {
-		this.getRegionFromBlock(x, y, z).unloadChunk(x, y, z, save);
+		SpoutRegion r = this.getRegion(x >> Region.REGION_SIZE_BITS, y >> Region.REGION_SIZE_BITS, z >> Region.REGION_SIZE_BITS, false);
+		if (r != null) {
+			r.unloadChunk(x & Region.REGION_SIZE - 1, y & Region.REGION_SIZE - 1, z & Region.REGION_SIZE - 1, save);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
The World interface shows the definition of the getChunk(), unloadChunk() and saveChunk() APIs as using X, Y, and Z as 'chunk coordinates' (corresponding to 1/16 the equivalent block coordinates). The implementation of unloadChunk and saveChunk both use the coordinates incorrectly: first, using them as block coordinates to get the region, and then using them as relative chunk coordinates within the region. This typically causes Array index out of bounds exceptions.

Signed-off-by: Mike Primm mike@primmhome.com
