### PR TITLE
SPOUT-49: Make getRegion(LoadGenerateOption.LOAD_IF_NEEDED) not create region, chunks

### DIFF
--- a/src/main/java/org/spout/engine/world/RegionSource.java
+++ b/src/main/java/org/spout/engine/world/RegionSource.java
@@ -139,6 +139,10 @@ public class RegionSource implements Iterable<Region> {
 		if (region != null || (!loadopt.loadIfNeeded())) {
 			return region;
 		} else {
+			/* If not generating region, and it doesn't exist yet, we're done */
+			if ((!loadopt.generateIfNeeded()) && (!SpoutRegion.regionFileExists(world, x, y, z))) {
+				return null;
+			}
 			region = new SpoutRegion(world, x, y, z, this);
 			SpoutRegion current = (SpoutRegion) loadedRegions.putIfAbsent(x, y, z, region);
 

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -904,4 +904,22 @@ public class SpoutRegion extends Region {
 		// TODO Auto-generated method stub
 		return null;
 	}
+	
+	/**
+	 * Test if region file exists
+	 * 
+	 * @param world world
+	 * @param x region x coordinate
+	 * @param y region y coordinate
+	 * @param z region z coordinate
+	 * 
+	 * @return true if exists, false if doesn't exist
+	 */
+	
+	public static boolean regionFileExists(SpoutWorld world, int x, int y, int z) {
+		File worldDirectory = world.getDirectory();
+		File regionDirectory = new File(worldDirectory, "region");
+		File regionFile = new File(regionDirectory, "reg" + x + "_" + y + "_" + z + ".spr");
+		return regionFile.exists();
+	}
 }


### PR DESCRIPTION
The getRegion() call with LoadGenerateOption.LOAD_IF_NEEDED doesn't prevent SpoutRegion from being created, which results in the region file being created (and, typically, at least one chunk being generated due to entity spawning being processed before the region unloads). The generated chunks can lead world traversal mods, like dynmap, to continue to walk the world - resulting in an ever-expanding set of nearly empty region files.

This change makes it so that, when the region isn't supposed to be generated, the region file is checked and the SpoutRegion isn't created if it doesn't exist.

Signed-off-by: Mike Primm mike@primmhome.com
