### PR TITLE
Add chunk load/unload/populate/update events 

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -149,7 +149,6 @@ public class SpoutChunk extends Chunk {
 	 * True if this chunk requires a full lighting re-initialization
 	 */
 	protected final AtomicBoolean isLightingInit = new AtomicBoolean(false);
-
 	/**
 	 * Data map and Datatable associated with it
 	 */
@@ -198,6 +197,7 @@ public class SpoutChunk extends Chunk {
 		column.registerChunk();
 		columnRegistered.set(true);
 		lastUnloadCheck.set(world.getAge());
+		blockStore.resetDirtyArrays();	// Clear false dirty state on freshly loaded chunk
 		this.biomes = manager;
 	}
 

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -28,6 +28,7 @@ package org.spout.engine.world;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,6 +50,10 @@ import org.spout.api.entity.BlockController;
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
 import org.spout.api.entity.PlayerController;
+import org.spout.api.event.chunk.ChunkLoadEvent;
+import org.spout.api.event.chunk.ChunkPopulateEvent;
+import org.spout.api.event.chunk.ChunkUnloadEvent;
+import org.spout.api.event.chunk.ChunkUpdatedEvent;
 import org.spout.api.generator.WorldGenerator;
 import org.spout.api.generator.biome.Biome;
 import org.spout.api.generator.biome.BiomeManager;
@@ -219,13 +224,14 @@ public class SpoutRegion extends Region {
 			AtomicReference<SpoutChunk> ref = chunks[x][y][z];
 
 			boolean success = false;
-
+			boolean generated = false;
 			SpoutChunk newChunk = WorldFiles.loadChunk(this, x, y, z, this.getChunkInputStream(x, y, z));
 			if (newChunk == null) {
 				if (!loadopt.generateIfNeeded()) {
 					return null;
 				}
 				newChunk = generateChunk(x, y, z);
+				generated = true;
 			}
 
 			while (!success) {
@@ -238,6 +244,9 @@ public class SpoutRegion extends Region {
 						nonPopulatedChunks.add(newChunk);
 					}
 					runningChunksQueue.add(newChunk);
+
+					Spout.getEventManager().callDelayedEvent(new ChunkLoadEvent(newChunk, generated));
+
 					return newChunk;
 				} else {
 					newChunk.deregisterFromColumn(false);
@@ -546,7 +555,16 @@ public class SpoutRegion extends Region {
 
 				Chunk toUnload = unloadQueue.poll();
 				if (toUnload != null) {
-					toUnload.unload(true);
+					boolean do_unload = true;
+					if (ChunkUnloadEvent.getHandlerList().getRegisteredListeners().length > 0) {
+						ChunkUnloadEvent event = Spout.getEngine().getEventManager().callEvent(new ChunkUnloadEvent(toUnload));
+						if (event.isCancelled()) {
+							do_unload = false;
+						}
+					}
+					if (do_unload) {
+						toUnload.unload(true);
+					}
 				}
 
 				break;
@@ -607,8 +625,17 @@ public class SpoutRegion extends Region {
 				chunkCompressed |= ((SpoutChunk) chunk).compressIfRequired();
 
 				if (reaped < REAP_PER_TICK && ((SpoutChunk) chunk).isReapable(worldAge)) {
-					((SpoutChunk) chunk).unload(true);
-					reaped++;
+					boolean do_unload = true;
+					if (ChunkUnloadEvent.getHandlerList().getRegisteredListeners().length > 0) {
+						ChunkUnloadEvent event = Spout.getEngine().getEventManager().callEvent(new ChunkUnloadEvent(chunk));
+						if (event.isCancelled()) {
+							do_unload = false;
+						}
+					}
+					if (do_unload) {
+						((SpoutChunk) chunk).unload(true);
+						reaped++;
+					}
 				}
 			}
 		}
@@ -639,6 +666,32 @@ public class SpoutRegion extends Region {
 			}
 		}
 	}
+	
+	private void processChunkUpdatedEvent(SpoutChunk chunk) {
+		/* If no listeners, quit */
+		if (ChunkUpdatedEvent.getHandlerList().getRegisteredListeners().length == 0) {
+			return;
+		}
+		ChunkUpdatedEvent evt;
+		if (chunk.isDirtyOverflow()) {	/* If overflow, notify for whole chunk */
+			evt = new ChunkUpdatedEvent(chunk, null);
+		}
+		else {
+			ArrayList<Vector3> lst = new ArrayList<Vector3>();
+			boolean done = false;
+			for (int i = 0; !done; i++) {
+				Vector3 v = chunk.getDirtyBlock(i);
+				if (v != null) {
+					lst.add(v);
+				}
+				else {
+					done = true;
+				}
+			}
+			evt = new ChunkUpdatedEvent(chunk, lst);
+		}
+		Spout.getEventManager().callDelayedEvent(evt);
+	}
 
 	public void preSnapshotRun() throws InterruptedException {
 		entityManager.preSnapshotRun();
@@ -660,6 +713,8 @@ public class SpoutRegion extends Region {
 							}
 							syncChunkToPlayers(spoutChunk, entity);
 						}
+						processChunkUpdatedEvent(spoutChunk);
+						
 						spoutChunk.resetDirtyArrays();
 					}
 				}
@@ -716,6 +771,7 @@ public class SpoutRegion extends Region {
 		if (!isPopulatingChunks) {
 			nonPopulatedChunks.remove(chunk);
 		}
+		Spout.getEventManager().callDelayedEvent(new ChunkPopulateEvent(chunk));
 	}
 
 	@Override


### PR DESCRIPTION
Add events for various chunk lifecycle points:
1) Chunk loaded, including when chunk is generated
2) Chunk populated
3) Chunk unloaded
4) Chunk updated (based on reporting dirty block coordinates or whole chunk update, as used in network synchronizer).

All are non-cancellable, monitor style events, useful for monitoring world data changes without interfering with them (whether driven by player action or by plugins).

Codependent with SpoutAPI pull https://github.com/SpoutDev/SpoutAPI/pull/218.

Signed-off-by: Mike Primm mike@primmhome.com
