### PR TITLE
Implemented basic sky lighting

### DIFF
--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -25,6 +25,7 @@
  */
 package org.spout.engine.world;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -45,6 +46,13 @@ public class FilteredChunk extends SpoutChunk{
 	private final AtomicBoolean uniform;
 	private final AtomicInteger uniformId = new AtomicInteger(0);
 	private final AtomicReference<BlockMaterial> material = new AtomicReference<BlockMaterial>(null);
+
+	protected final static byte[] DARK = new byte[Chunk.CHUNK_VOLUME / 2];
+	protected final static byte[] LIGHT = new byte[Chunk.CHUNK_VOLUME / 2];
+
+	static {
+		Arrays.fill(LIGHT, (byte) 255);
+	}
 
 	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
 		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
@@ -161,7 +169,14 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.getBlockLight(x, y, z);
 	}
-	
+
+	@Override
+	public void initLighting() {
+		if (!uniform.get()) {
+			super.initLighting();
+		}
+	}
+
 	@Override
 	public void syncSave() {
 		if (uniform.get()) {
@@ -184,10 +199,10 @@ public class FilteredChunk extends SpoutChunk{
 			for (int i = 0; i < initial.length; i++) {
 				initial[i] = id;
 			}
-			
+
 			byte[] skyLight = new byte[CHUNK_VOLUME / 2];
 			System.arraycopy(this.getY() < 4 ? DARK : LIGHT, 0, skyLight, 0, skyLight.length);
-			
+
 			byte[] blockLight = new byte[CHUNK_VOLUME / 2];
 			System.arraycopy(DARK, 0, blockLight, 0, blockLight.length);
 			return new SpoutChunkSnapshot(this, initial, new short[Chunk.CHUNK_VOLUME], blockLight, skyLight, entities);

--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -60,7 +60,7 @@ import org.spout.api.math.Vector3;
 import org.spout.api.player.Player;
 import org.spout.api.protocol.NetworkSynchronizer;
 import org.spout.api.scheduler.TickStage;
-import org.spout.api.util.hashing.TNibbleDualHashed;
+import org.spout.api.util.hashing.NibblePairHashed;
 import org.spout.api.util.map.concurrent.AtomicBlockStore;
 
 import org.spout.engine.entity.SpoutEntity;
@@ -266,11 +266,11 @@ public class SpoutChunk extends Chunk {
 		byte old = blockLight[index / 2];
 		byte oldLight;
 		if ((index & 1) == 0) {
-			oldLight = TNibbleDualHashed.key1(old);
-			blockLight[index / 2] = TNibbleDualHashed.key(light, old);
+			oldLight = NibblePairHashed.key1(old);
+			blockLight[index / 2] = NibblePairHashed.key(light, old);
 		} else {
-			oldLight = TNibbleDualHashed.key2(old);
-			blockLight[index / 2] = TNibbleDualHashed.key(old, light);
+			oldLight = NibblePairHashed.key2(old);
+			blockLight[index / 2] = NibblePairHashed.key(old, light);
 		}
 		if (light > oldLight) {
 			//light increased
@@ -291,9 +291,9 @@ public class SpoutChunk extends Chunk {
 		int index = getBlockIndex(x, y, z);
 		byte light = blockLight[index / 2];
 		if ((index & 1) == 0) {
-			return TNibbleDualHashed.key1(light);
+			return NibblePairHashed.key1(light);
 		} else {
-			return TNibbleDualHashed.key2(light);
+			return NibblePairHashed.key2(light);
 		}
 	}
 
@@ -310,11 +310,11 @@ public class SpoutChunk extends Chunk {
 		byte oldLight;
 
 		if ((index & 1) == 1) {
-			oldLight = TNibbleDualHashed.key1(old);
-			skyLight[index / 2] = TNibbleDualHashed.key(light, old);
+			oldLight = NibblePairHashed.key1(old);
+			skyLight[index / 2] = NibblePairHashed.key(light, old);
 		} else {
-			oldLight = TNibbleDualHashed.key2(old);
-			skyLight[index / 2] = TNibbleDualHashed.key(old, light);
+			oldLight = NibblePairHashed.key2(old);
+			skyLight[index / 2] = NibblePairHashed.key(old, light);
 		}
 		if (light > oldLight) {
 			//light increased
@@ -335,9 +335,9 @@ public class SpoutChunk extends Chunk {
 		int index = getBlockIndex(x, y, z);
 		byte light = skyLight[index / 2];
 		if ((index & 1) == 1) {
-			return TNibbleDualHashed.key1(light);
+			return NibblePairHashed.key1(light);
 		} else {
-			return TNibbleDualHashed.key2(light);
+			return NibblePairHashed.key2(light);
 		}
 	}
 

--- a/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
@@ -102,10 +102,11 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 	public byte getBlockSkyLight(int x, int y, int z) {
 		int index = this.getBlockIndex(x, y, z);
 		byte light = skyLight[index / 2];
-		if ((index & 1) == 0) {
-			return (byte) ((light >> CHUNK_SIZE_BITS) & 0xF);
+		if ((index & 1) == 1) {
+			return (byte) ((light >> 4) & 0xF);
+		} else {
+			return (byte) (light & 0xF);
 		}
-		return (byte) (light & 0xF);
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/world/SpoutColumn.java
+++ b/src/main/java/org/spout/engine/world/SpoutColumn.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.spout.api.Spout;
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Chunk;
-import org.spout.api.material.BlockMaterial;
 import org.spout.api.scheduler.TickStage;
 
 public class SpoutColumn {
@@ -159,19 +158,11 @@ public class SpoutColumn {
 		int xx = (this.x << COLUMN_SIZE_BITS) + (x & BIT_MASK);
 		int yy = y;
 		int zz = (this.z << COLUMN_SIZE_BITS) + (z & BIT_MASK);
-		return isAir(world.getBlockMaterial(xx, yy, zz));
+		return world.getBlockMaterial(xx, yy, zz).isTransparent();
 	}
 
 	private boolean isAir(Chunk c, int x, int y, int z) {
-		return isAir(c.getBlockMaterial(x, y, z));
-	}
-
-	private boolean isAir(BlockMaterial m) {
-		if (m == null) {
-			return false;
-		} else {
-			return m.getOpacity() == 0;
-		}
+		return c.getBlockMaterial(x, y, z).isTransparent();
 	}
 
 	private AtomicInteger getAtomicInteger(int x, int z) {

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -98,11 +98,6 @@ public class SpoutRegion extends Region {
 	 */
 	private static final int REAP_PER_TICK = 1;
 	/**
-	 * The maximum number of chunks that will be processed for lighting updates
-	 * each tick.
-	 */
-	private static final int LIGHT_PER_TICK = 20;
-	/**
 	 * The segment size to use for chunk storage. The actual size is
 	 * 2^(SEGMENT_SIZE)
 	 */
@@ -143,10 +138,6 @@ public class SpoutRegion extends Region {
 	 */
 	//TODO thresholds?
 	private final TByteTripleObjectHashMap<Source> queuedPhysicsUpdates = new TByteTripleObjectHashMap<Source>();
-	/**
-	 * A queue of chunks that have columns of light that need to be recalculated
-	 */
-	private final Queue<SpoutChunk> lightingQueue = new ConcurrentLinkedQueue<SpoutChunk>();
 	/**
 	 * A queue of chunks that need to be populated
 	 */
@@ -455,12 +446,6 @@ public class SpoutRegion extends Region {
 		}
 	}
 
-	protected void queueLighting(SpoutChunk c) {
-		if (!lightingQueue.contains(c)) {
-			lightingQueue.add(c);
-		}
-	}
-
 	public void addEntity(Entity e) {
 		Controller controller = e.getController();
 		if (controller instanceof BlockController) {
@@ -521,16 +506,6 @@ public class SpoutRegion extends Region {
 							Block block = world.getBlock(x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ(), source);
 							material.onUpdate(block);
 						}
-					}
-				}
-
-				for (int i = 0; i < LIGHT_PER_TICK; i++) {
-					SpoutChunk toLight = lightingQueue.poll();
-					if (toLight == null) {
-						break;
-					}
-					if (toLight.isLoaded()) {
-						toLight.processQueuedLighting();
 					}
 				}
 

--- a/src/main/java/org/spout/engine/world/SpoutWorld.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorld.java
@@ -67,9 +67,9 @@ import org.spout.api.math.MathHelper;
 import org.spout.api.math.Vector3;
 import org.spout.api.player.Player;
 import org.spout.api.scheduler.TaskManager;
-import org.spout.api.util.HashUtil;
 import org.spout.api.util.StringMap;
-import org.spout.api.util.hashing.TNibbleDualHashed;
+import org.spout.api.util.hashing.IntPairHashed;
+import org.spout.api.util.hashing.NibblePairHashed;
 import org.spout.api.util.map.concurrent.TSyncIntPairObjectHashMap;
 import org.spout.api.util.map.concurrent.TSyncLongObjectHashMap;
 import org.spout.api.util.sanitation.StringSanitizer;
@@ -660,7 +660,7 @@ public class SpoutWorld extends AsyncManager implements World {
 	 * @param z the z coordinate
 	 */
 	public void removeColumn(int x, int z, SpoutColumn column) {
-		long key = HashUtil.intToLong(x, z);
+		long key = IntPairHashed.key(x, z);
 		columns.remove(key, column);
 	}
 
@@ -675,7 +675,7 @@ public class SpoutWorld extends AsyncManager implements World {
 	public SpoutColumn getColumn(int x, int z, boolean create) {
 		int colX = x >> SpoutColumn.COLUMN_SIZE_BITS;
 		int colZ = z >> SpoutColumn.COLUMN_SIZE_BITS;
-		long key = HashUtil.intToLong(colX, colZ);
+		long key = IntPairHashed.key(colX, colZ);
 		SpoutColumn column = columns.get(key);
 		if (create && column == null) {
 			SpoutColumn newColumn = new SpoutColumn(this, colX, colZ);
@@ -717,7 +717,7 @@ public class SpoutWorld extends AsyncManager implements World {
 
 		BAAWrapper baa = getColumnHeightMapBAA(x, z);
 
-		int key = TNibbleDualHashed.key(x, z) & 0xFF;
+		int key = NibblePairHashed.key(x, z) & 0xFF;
 
 		return baa.getBlockInputStream(key);
 	}
@@ -726,7 +726,7 @@ public class SpoutWorld extends AsyncManager implements World {
 
 		BAAWrapper baa = getColumnHeightMapBAA(x, z);
 
-		int key = TNibbleDualHashed.key(x, z) & 0xFF;
+		int key = NibblePairHashed.key(x, z) & 0xFF;
 
 		return baa.getBlockOutputStream(key);
 	}

--- a/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
@@ -1,0 +1,202 @@
+package org.spout.engine.world;
+
+import gnu.trove.iterator.TLongIterator;
+import gnu.trove.list.TLongList;
+import gnu.trove.list.array.TLongArrayList;
+
+import org.spout.api.Source;
+import org.spout.api.material.BlockMaterial;
+import org.spout.api.material.block.BlockFace;
+import org.spout.api.material.block.BlockFaces;
+import org.spout.api.util.hashing.TInt21TripleHashed;
+import org.spout.api.util.set.TInt21TripleHashSet;
+
+public class SpoutWorldLighting extends Thread implements Source {
+
+	public static class Section {
+		private final TInt21TripleHashSet updates = new TInt21TripleHashSet();
+		private TLongIterator iter; //temporary
+
+		public void add(int x, int y, int z) {
+			synchronized (updates) {
+				//updates.add(x, y, z);
+			}
+		}
+
+		public boolean transfer(TLongList list) {
+			list.clear();
+			synchronized (updates) {
+				if (updates.isEmpty()) {
+					return false;
+				}
+				iter = updates.iterator();
+				while (iter.hasNext()) {
+					list.add(iter.next());
+				}
+				updates.clear();
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * A model representing the center block with all neighbours
+	 */
+	public static class DiamondLightModel {
+		public final Element[] neighbours;
+		public final Element center;
+
+		public DiamondLightModel(SpoutWorld world, boolean sky) {
+			this.neighbours = new Element[6];
+			for (int i = 0; i < this.neighbours.length; i++) {
+				BlockFace face = BlockFaces.NESWBT.get(i);
+				this.neighbours[i] = sky ? new SkyElement(world, face) : new BlockElement(world, face);
+			}
+			this.center = sky ? new SkyElement(world, BlockFace.THIS) : new BlockElement(world, BlockFace.THIS);
+		}
+
+		public DiamondLightModel load(long key) {
+			return this.load(TInt21TripleHashed.key1(key), TInt21TripleHashed.key2(key), TInt21TripleHashed.key3(key));
+		}
+
+		public DiamondLightModel load(int x, int y, int z) {
+			this.center.load(x, y, z);
+			for (Element element : this.neighbours) {
+				element.load(x, y, z);
+			}
+			return this;
+		}
+
+		public void doGreater() {
+			for (Element element : this.neighbours) {
+				if (!center.material.occludes(element.offset)) {
+					if (!element.material.occludes(element.offset.getOpposite())) {
+						if (center.lightToNeighbours > element.light) {
+							element.setLight(center.lightToNeighbours);
+						}
+					}
+				}
+			}
+		}
+
+		public static class BlockElement extends Element {
+			private byte blockLight;
+
+			public BlockElement(SpoutWorld world, BlockFace offset) {
+				super(world, offset);
+			}
+
+			@Override
+			public void load(int x, int y, int z) {
+				super.load(x, y, z);
+				this.blockLight = this.material.getLightLevel(this.data);
+				this.light = this.chunk.getBlockLight(x, y, z);
+			}
+
+			@Override
+			public void setLight(byte light) {
+				this.light = light;
+				if (this.light < this.blockLight) {
+					this.light = this.blockLight;
+				}
+				this.chunk.setBlockLight(this.x, this.y, this.z, this.light, this.world);
+			}
+		}
+
+		public static class SkyElement extends Element {
+			public SkyElement(SpoutWorld world, BlockFace offset) {
+				super(world, offset);
+			}
+
+			@Override
+			public void load(int x, int y, int z) {
+				super.load(x, y, z);
+				this.light = this.chunk.getBlockSkyLight(x, y, z);
+			}
+
+			@Override
+			public void setLight(byte light) {
+				if (this.light != 15) {
+					this.chunk.setBlockSkyLight(this.x, this.y, this.z, light, this.world);
+				}
+			}
+		}
+
+		public static abstract class Element {
+			public int x, y, z;
+			public SpoutChunk chunk;
+			public BlockMaterial material;
+			public short data;
+			public byte light;
+			public byte lightToNeighbours;
+			public BlockFace offset;
+			public final SpoutWorld world;
+
+			public Element(SpoutWorld world, BlockFace offset) {
+				this.offset = offset;
+				this.world = world;
+			}
+
+			public void load(int x, int y, int z) {
+				this.x = x + (int) this.offset.getOffset().getX();
+				this.y = y + (int) this.offset.getOffset().getY();
+				this.z = z + (int) this.offset.getOffset().getZ();
+				this.chunk = this.world.getChunkFromBlock(x, y, z, true);
+				this.material = this.chunk.getBlockMaterial(x, y, z);
+				this.data = this.chunk.getBlockData(x, y, z);
+				this.material = this.material.getSubMaterial(this.data);
+				this.lightToNeighbours = (byte) (this.light - this.material.getOpacity() - 1);
+				if (this.lightToNeighbours < 0) {
+					this.lightToNeighbours = 0;
+				}
+			}
+
+			public abstract void setLight(byte light);
+		}
+	}
+
+	public final Section skyLightGreater = new Section();
+	public final Section skyLightLesser = new Section();
+	public final Section blockLightGreater = new Section();
+	public final Section blockLightLesser = new Section();
+	private final SpoutWorld world;
+	private boolean running = true;
+
+	public SpoutWorldLighting(SpoutWorld world) {
+		super("Lighting thread for world " + world.getName());
+		this.world = world;
+	}
+
+	public void abort() {
+		this.running = false;
+	}
+
+	@Override
+	public void run() {
+		this.running = true; //TODO: For now block light smoothing is DISABLED until it is stable enough.
+		TLongList updates = new TLongArrayList();
+		TLongIterator iter;
+		DiamondLightModel skyModel = new DiamondLightModel(this.world, true);
+		DiamondLightModel blockModel = new DiamondLightModel(this.world, false);
+		while (this.running) {
+			//Perform greatening sky light
+			if (this.skyLightGreater.transfer(updates)) {
+				iter = updates.iterator();
+				while (iter.hasNext()) {
+					skyModel.load(iter.next()).doGreater();
+				}
+			}
+			//Perform greatening block light
+			if (this.blockLightGreater.transfer(updates)) {
+				iter = updates.iterator();
+				while (iter.hasNext()) {
+					blockModel.load(iter.next()).doGreater();
+				}
+			}
+
+			try {
+				Thread.sleep(50);
+			} catch (InterruptedException ex) {}
+		}
+	}
+}

--- a/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
@@ -8,7 +8,7 @@ import org.spout.api.Source;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFace;
 import org.spout.api.material.block.BlockFaces;
-import org.spout.api.util.hashing.TInt21TripleHashed;
+import org.spout.api.util.hashing.Int21TripleHashed;
 import org.spout.api.util.set.TInt21TripleHashSet;
 
 public class SpoutWorldLighting extends Thread implements Source {
@@ -56,7 +56,7 @@ public class SpoutWorldLighting extends Thread implements Source {
 		}
 
 		public DiamondLightModel load(long key) {
-			return this.load(TInt21TripleHashed.key1(key), TInt21TripleHashed.key2(key), TInt21TripleHashed.key3(key));
+			return this.load(Int21TripleHashed.key1(key), Int21TripleHashed.key2(key), Int21TripleHashed.key3(key));
 		}
 
 		public DiamondLightModel load(int x, int y, int z) {


### PR DESCRIPTION
Signed-off-by: berger killer bergerkiller@gmail.com

Sky lighting (the column-based lighting) is fully implemented and works without the aid of a scheduled thread. I decided to do that to prevent a lot of unneeded (long) memory usage to store all chunks or column coordinates. All the lighting thread will do is smooth single-block lighting.

In this PR I disabled the lighting thread (running = false) as the current smooth code is untested and incomplete. Block light still needs some implementation, but will probably be nothing but smoothing.

Discussion: Should block updates be stored in the region, chunk or world, and which would have the best performance benefit? Note that block updates are scheduled very very often while smoothing, which is why I choose to store it in a long hashset (int21triple)

This code has been tested and works 100% of the time for vertical sky light. Dark shadows remain under blocks though.

See also:
https://github.com/VanillaDev/Vanilla/pull/208
https://github.com/SpoutDev/SpoutAPI/pull/226
