### PR TITLE
Added check when sending chunk for pending light

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -443,10 +443,8 @@ public class SpoutChunk extends Chunk {
 	}
 
 	private void notifyLightChange() {
-		if (SpoutConfiguration.LIVE_LIGHTING.getBoolean()) {
-			if (this.lightingCounter.getAndSet(0) == -1) {
-				this.parentRegion.reportChunkLightDirty(this.getX(), this.getY(), this.getZ());
-			}
+		if (this.lightingCounter.getAndSet(0) == -1) {
+			this.parentRegion.reportChunkLightDirty(this.getX(), this.getY(), this.getZ());
 		}
 	}
 
@@ -642,6 +640,10 @@ public class SpoutChunk extends Chunk {
 
 	public boolean isDirty() {
 		return lightDirty.get() || blockStore.isDirty();
+	}
+
+	public boolean isCalculatingLighting() {
+		return this.lightingCounter.get() >= 0;
 	}
 
 	public boolean isDirtyOverflow() {


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

It was sending chunks which were still undergoing lighting calculations, which caused the client to lag like crazy when entering newly populated chunks. This should deal with this problem.
