### PR TITLE
Massive compatibility update for SpoutAPI and lighting

### DIFF
--- a/src/main/java/org/spout/engine/entity/SpoutEntity.java
+++ b/src/main/java/org/spout/engine/entity/SpoutEntity.java
@@ -47,6 +47,7 @@ import org.spout.api.entity.PlayerController;
 import org.spout.api.entity.component.EntityComponent;
 import org.spout.api.event.entity.EntityControllerChangeEvent;
 import org.spout.api.event.entity.EntityMoveEvent;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.Region;
@@ -124,7 +125,7 @@ public class SpoutEntity implements Entity, Tickable {
 	}
 
 	public SpoutEntity(SpoutEngine engine, Transform transform, Controller controller) {
-		this(engine, transform, controller, SpoutConfiguration.VIEW_DISTANCE.getInt() * SpoutChunk.CHUNK_SIZE);
+		this(engine, transform, controller, SpoutConfiguration.VIEW_DISTANCE.getInt() * Chunk.BLOCKS.SIZE);
 	}
 
 	public SpoutEntity(SpoutEngine engine, Point point, Controller controller) {
@@ -178,7 +179,7 @@ public class SpoutEntity implements Entity, Tickable {
 		 */
 		if (!isDead() && getPosition() != null && getWorld() != null) {
 			//Note: if the chunk is null, this effectively kills the entity (since dead: {chunkLive.get() == null})
-			chunkLive.set(getWorld().getChunkFromBlock(transform.getPosition(), false));
+			chunkLive.set(getWorld().getChunkFromBlock(transform.getPosition(), LoadOption.NO_LOAD));
 			entityManagerLive.set(((SpoutRegion)getRegion()).getEntityManager());
 		}
 	}
@@ -599,7 +600,7 @@ public class SpoutEntity implements Entity, Tickable {
 		if (controllerLive.get() instanceof PlayerController) {
 			return;
 		}
-		final int viewDistance = getViewDistance() / Chunk.CHUNK_SIZE;
+		final int viewDistance = getViewDistance() >> Chunk.BLOCKS.BITS;
 		World w = getWorld();
 		int cx = chunkLive.get().getX();
 		int cy = chunkLive.get().getY();
@@ -608,7 +609,7 @@ public class SpoutEntity implements Entity, Tickable {
 		for (int dx = -viewDistance; dx < viewDistance; dx++) {
 			for (int dy = -viewDistance; dy < viewDistance; dy++) {
 				for (int dz = -viewDistance; dz < viewDistance; dz++) {
-					Chunk chunk = w.getChunk(cx + dx, cy + dy, cz + dz, true);
+					Chunk chunk = w.getChunk(cx + dx, cy + dy, cz + dz);
 					chunk.refreshObserver(this);
 					observing.add((SpoutChunk)chunk);
 				}

--- a/src/main/java/org/spout/engine/filesystem/WorldFiles.java
+++ b/src/main/java/org/spout/engine/filesystem/WorldFiles.java
@@ -250,9 +250,9 @@ public class WorldFiles {
 			is = new NBTInputStream(dis, false);
 			CompoundTag chunkTag = (CompoundTag) is.readTag();
 			CompoundMap map = chunkTag.getValue();
-			int cx = (r.getX() << Region.REGION_SIZE_BITS) + x;
-			int cy = (r.getY() << Region.REGION_SIZE_BITS) + y;
-			int cz = (r.getZ() << Region.REGION_SIZE_BITS) + z;
+			int cx = (r.getX() << Region.CHUNKS.BITS) + x;
+			int cy = (r.getY() << Region.CHUNKS.BITS) + y;
+			int cz = (r.getZ() << Region.CHUNKS.BITS) + z;
 
 			boolean populated = SafeCast.toGeneric(map.get("populated"), new ByteTag("", false), ByteTag.class).getBooleanValue();
 			short[] blocks = SafeCast.toShortArray(toTagValue(map.get("blocks")), null);

--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -35,7 +35,6 @@ import org.spout.api.Source;
 import org.spout.api.datatable.DataMap;
 import org.spout.api.datatable.DatatableMap;
 import org.spout.api.generator.biome.BiomeManager;
-import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.ChunkSnapshot;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFullState;
@@ -48,8 +47,8 @@ public class FilteredChunk extends SpoutChunk{
 	private final AtomicInteger uniformId = new AtomicInteger(0);
 	private final AtomicReference<BlockMaterial> material = new AtomicReference<BlockMaterial>(null);
 
-	protected final static byte[] DARK = new byte[Chunk.CHUNK_VOLUME / 2];
-	protected final static byte[] LIGHT = new byte[Chunk.CHUNK_VOLUME / 2];
+	protected final static byte[] DARK = new byte[BLOCKS.HALF_VOLUME];
+	protected final static byte[] LIGHT = new byte[BLOCKS.HALF_VOLUME];
 
 	static {
 		Arrays.fill(LIGHT, (byte) 255);
@@ -82,17 +81,17 @@ public class FilteredChunk extends SpoutChunk{
 
 	private synchronized void initialize() {
 		if (uniform.get()) {
-			short[] initial = new short[Chunk.CHUNK_VOLUME];
+			short[] initial = new short[BLOCKS.VOLUME];
 			short id = (short)uniformId.get();
 			for (int i = 0; i < initial.length; i++) {
 				initial[i] = id;
 			}
-			this.blockStore = new AtomicBlockStoreImpl(Chunk.CHUNK_SIZE_BITS, 10, initial);
+			this.blockStore = new AtomicBlockStoreImpl(BLOCKS.BITS, 10, initial);
 			
-			this.skyLight = new byte[CHUNK_VOLUME / 2];
+			this.skyLight = new byte[BLOCKS.HALF_VOLUME];
 			System.arraycopy(this.getY() < 4 ? DARK : LIGHT, 0, this.skyLight, 0, this.skyLight.length);
 			
-			this.blockLight = new byte[CHUNK_VOLUME / 2];
+			this.blockLight = new byte[BLOCKS.HALF_VOLUME];
 			System.arraycopy(DARK, 0, this.blockLight, 0, this.blockLight.length);
 			
 			uniform.set(false);
@@ -185,12 +184,12 @@ public class FilteredChunk extends SpoutChunk{
 	@Override
 	public void syncSave() {
 		if (uniform.get()) {
-			short[] initial = new short[Chunk.CHUNK_VOLUME];
+			short[] initial = new short[BLOCKS.VOLUME];
 			short id = (short)uniformId.get();
 			for (int i = 0; i < initial.length; i++) {
 				initial[i] = id;
 			}
-			WorldFiles.saveChunk(this, initial, new short[Chunk.CHUNK_VOLUME], this.getY() < 4 ? DARK : LIGHT, DARK, datatableMap, this.parentRegion.getChunkOutputStream(this));
+			WorldFiles.saveChunk(this, initial, new short[BLOCKS.VOLUME], this.getY() < 4 ? DARK : LIGHT, DARK, datatableMap, this.parentRegion.getChunkOutputStream(this));
 		} else {
 			super.syncSave();
 		}
@@ -199,18 +198,18 @@ public class FilteredChunk extends SpoutChunk{
 	@Override
 	public ChunkSnapshot getSnapshot(boolean entities) {
 		if (uniform.get()) {
-			short[] initial = new short[Chunk.CHUNK_VOLUME];
+			short[] initial = new short[BLOCKS.VOLUME];
 			short id = (short)uniformId.get();
 			for (int i = 0; i < initial.length; i++) {
 				initial[i] = id;
 			}
 
-			byte[] skyLight = new byte[CHUNK_VOLUME / 2];
+			byte[] skyLight = new byte[BLOCKS.HALF_VOLUME];
 			System.arraycopy(this.getY() < 4 ? DARK : LIGHT, 0, skyLight, 0, skyLight.length);
 
-			byte[] blockLight = new byte[CHUNK_VOLUME / 2];
+			byte[] blockLight = new byte[BLOCKS.HALF_VOLUME];
 			System.arraycopy(DARK, 0, blockLight, 0, blockLight.length);
-			return new SpoutChunkSnapshot(this, initial, new short[Chunk.CHUNK_VOLUME], blockLight, skyLight, entities);
+			return new SpoutChunkSnapshot(this, initial, new short[BLOCKS.VOLUME], blockLight, skyLight, entities);
 		}
 		return super.getSnapshot(entities);
 	}

--- a/src/main/java/org/spout/engine/world/RegionSource.java
+++ b/src/main/java/org/spout/engine/world/RegionSource.java
@@ -33,14 +33,12 @@ import java.util.Iterator;
 import org.spout.api.Spout;
 import org.spout.api.event.world.RegionLoadEvent;
 import org.spout.api.event.world.RegionUnloadEvent;
-import org.spout.api.geo.LoadGenerateOption;
-import org.spout.api.geo.cuboid.Chunk;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.cuboid.Region;
 import org.spout.api.scheduler.TaskManager;
 import org.spout.api.util.map.concurrent.TSyncInt21TripleObjectHashMap;
 import org.spout.api.util.thread.DelayedWrite;
 import org.spout.api.util.thread.LiveRead;
-import org.spout.api.util.thread.SnapshotRead;
 import org.spout.engine.scheduler.SpoutParallelTaskManager;
 import org.spout.engine.scheduler.SpoutScheduler;
 import org.spout.engine.util.thread.snapshotable.SnapshotManager;
@@ -58,32 +56,6 @@ public class RegionSource implements Iterable<Region> {
 	public RegionSource(SpoutWorld world, SnapshotManager snapshotManager) {
 		this.world = world;
 		loadedRegions = new TSyncInt21TripleObjectHashMap<Region>();
-	}
-
-	/**
-	 * Gets the region associated with the block x, y, z coordinates
-	 * @param x the x coordinate
-	 * @param y the y coordinate
-	 * @param z the z coordinate
-	 * @return region, if it is loaded and exists
-	 */
-	@SnapshotRead
-	public SpoutRegion getRegionFromBlock(int x, int y, int z) {
-		return getRegionFromBlock(x, y, z, LoadGenerateOption.NO_LOAD);
-	}
-
-	/**
-	 * Gets the region associated with the block x, y, z coordinates
-	 * @param x    the x coordinate
-	 * @param y    the y coordinate
-	 * @param z    the z coordinate
-	 * @param loadopt to control whether to load or generate the region, if needed
-	 * @return region
-	 */
-	@LiveRead
-	public SpoutRegion getRegionFromBlock(int x, int y, int z, LoadGenerateOption loadopt) {
-		int shifts = Region.REGION_SIZE_BITS + Chunk.CHUNK_SIZE_BITS;
-		return getRegion(x >> shifts, y >> shifts, z >> shifts, loadopt);
 	}
 
 	@DelayedWrite
@@ -127,7 +99,7 @@ public class RegionSource implements Iterable<Region> {
 	 */
 	@LiveRead
 	public SpoutRegion getRegion(int x, int y, int z) {
-		return getRegion(x, y, z, LoadGenerateOption.NO_LOAD);
+		return getRegion(x, y, z, LoadOption.NO_LOAD);
 	}
 
 	/**
@@ -142,7 +114,7 @@ public class RegionSource implements Iterable<Region> {
 	 * @return region
 	 */
 	@LiveRead
-	public SpoutRegion getRegion(int x, int y, int z, LoadGenerateOption loadopt) {
+	public SpoutRegion getRegion(int x, int y, int z, LoadOption loadopt) {
 		SpoutRegion region = (SpoutRegion) loadedRegions.get(x, y, z);
 
 		if (region != null || (!loadopt.loadIfNeeded())) {

--- a/src/main/java/org/spout/engine/world/SpoutBlock.java
+++ b/src/main/java/org/spout/engine/world/SpoutBlock.java
@@ -80,7 +80,7 @@ public class SpoutBlock implements Block {
 	@Override
 	public Chunk getChunk() {
 		if (this.chunk == null || !this.chunk.isLoaded()) {
-			this.chunk = this.world.getChunkFromBlock(this.x, this.y, this.z, true);
+			this.chunk = this.world.getChunkFromBlock(this.x, this.y, this.z);
 		}
 		return this.chunk;
 	}

--- a/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
@@ -46,10 +46,6 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 	 * The parent region that manages this chunk
 	 */
 	private final WeakReference<Region> parentRegion;
-	/**
-	 * The mask that should be applied to the x, y and z coords
-	 */
-	private final int coordMask;
 	
 	private final Set<WeakReference<Entity>> entities;
 	private final short[] blockIds;
@@ -61,7 +57,6 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 
 	public SpoutChunkSnapshot(SpoutChunk chunk, short[] blockIds, short[] blockData, byte[] blockLight, byte[] skyLight, boolean entities) {
 		super(chunk.getWorld(), chunk.getX(), chunk.getY(), chunk.getZ());
-		coordMask = Chunk.CHUNK_SIZE - 1;
 		parentRegion = new WeakReference<Region>(chunk.getRegion());
 		if (entities) {
 			Set<WeakReference<Entity>> liveEntities = new HashSet<WeakReference<Entity>>();
@@ -81,7 +76,7 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 	}
 
 	private int getBlockIndex(int x, int y, int z) {
-		return (y & this.coordMask) << 8 | (z & this.coordMask) << 4 | x & this.coordMask;
+		return (y & Chunk.BLOCKS.MASK) << 8 | (z & Chunk.BLOCKS.MASK) << 4 | x & Chunk.BLOCKS.MASK;
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/world/SpoutColumn.java
+++ b/src/main/java/org/spout/engine/world/SpoutColumn.java
@@ -37,23 +37,16 @@ import org.spout.api.Spout;
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.material.BlockMaterial;
-import org.spout.api.material.block.BlockFace;
 import org.spout.api.material.block.BlockFaces;
+import org.spout.api.math.BitSize;
 import org.spout.api.scheduler.TickStage;
 
 public class SpoutColumn {
 	/**
-	 * Internal size of a side of a column
+	 * Stores the size of the amount of blocks in this Column
 	 */
-	public final static int COLUMN_SIZE = Chunk.CHUNK_SIZE;
-	/**
-	 * Internal size of a side of a column
-	 */
-	public final static int BIT_MASK = COLUMN_SIZE - 1;
-	/**
-	 * Number of bits on the side of a column
-	 */
-	public final static int COLUMN_SIZE_BITS = Chunk.CHUNK_SIZE_BITS;
+	public static BitSize BLOCKS = Chunk.BLOCKS;
+
 	private final World world;
 	private final int x;
 	private final int z;
@@ -64,10 +57,10 @@ public class SpoutColumn {
 		this.world = world;
 		this.x = x;
 		this.z = z;
-		this.heightMap = new AtomicInteger[COLUMN_SIZE][COLUMN_SIZE];
+		this.heightMap = new AtomicInteger[BLOCKS.SIZE][BLOCKS.SIZE];
 
-		for (int xx = 0; xx < COLUMN_SIZE; xx++) {
-			for (int zz = 0; zz < COLUMN_SIZE; zz++) {
+		for (int xx = 0; xx < BLOCKS.SIZE; xx++) {
+			for (int zz = 0; zz < BLOCKS.SIZE; zz++) {
 				heightMap[xx][zz] = new AtomicInteger(0);
 			}
 		}
@@ -110,7 +103,7 @@ public class SpoutColumn {
 
 	public void notifyChunkAdded(Chunk c, int x, int z) {
 		int y = c.getBlockY();
-		int maxY = y + Chunk.CHUNK_SIZE - 1;
+		int maxY = y + Chunk.BLOCKS.SIZE - 1;
 		AtomicInteger v = getAtomicInteger(x, z);
 
 		if (maxY < v.get()) {
@@ -168,9 +161,9 @@ public class SpoutColumn {
 	}
 
 	private boolean isAir(int x, int y, int z) {
-		int xx = (this.x << COLUMN_SIZE_BITS) + (x & BIT_MASK);
+		int xx = (this.x << BLOCKS.BITS) + (x & BLOCKS.MASK);
 		int yy = y;
-		int zz = (this.z << COLUMN_SIZE_BITS) + (z & BIT_MASK);
+		int zz = (this.z << BLOCKS.BITS) + (z & BLOCKS.MASK);
 		return isAir(world.getBlockMaterial(xx, yy, zz));
 	}
 
@@ -183,14 +176,14 @@ public class SpoutColumn {
 	}
 
 	private AtomicInteger getAtomicInteger(int x, int z) {
-		return heightMap[x & BIT_MASK][z & BIT_MASK];
+		return heightMap[x & BLOCKS.MASK][z & BLOCKS.MASK];
 	}
 
 	private void readHeightMap(InputStream in) {
 		if (in == null) {
 			//The inputstream is null because no height map data exists
-			for (int x = 0; x < COLUMN_SIZE; x++) {
-				for (int z = 0; z < COLUMN_SIZE; z++) {
+			for (int x = 0; x < BLOCKS.SIZE; x++) {
+				for (int z = 0; z < BLOCKS.SIZE; z++) {
 					getAtomicInteger(x, z).set(Integer.MIN_VALUE);
 				}
 			}
@@ -199,8 +192,8 @@ public class SpoutColumn {
 
 		DataInputStream dataStream = new DataInputStream(in);
 		try {
-			for (int x = 0; x < COLUMN_SIZE; x++) {
-				for (int z = 0; z < COLUMN_SIZE; z++) {
+			for (int x = 0; x < BLOCKS.SIZE; x++) {
+				for (int z = 0; z < BLOCKS.SIZE; z++) {
 					getAtomicInteger(x, z).set(dataStream.readInt());
 				}
 			}
@@ -212,8 +205,8 @@ public class SpoutColumn {
 	private void writeHeightMap(OutputStream out) {
 		DataOutputStream dataStream = new DataOutputStream(out);
 		try {
-			for (int x = 0; x < COLUMN_SIZE; x++) {
-				for (int z = 0; z < COLUMN_SIZE; z++) {
+			for (int x = 0; x < BLOCKS.SIZE; x++) {
+				for (int z = 0; z < BLOCKS.SIZE; z++) {
 					dataStream.writeInt(getAtomicInteger(x, z).get());
 				}
 			}

--- a/src/main/java/org/spout/engine/world/SpoutWorld.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorld.java
@@ -55,7 +55,7 @@ import org.spout.api.entity.Entity;
 import org.spout.api.event.block.CuboidChangeEvent;
 import org.spout.api.generator.WorldGenerator;
 import org.spout.api.generator.biome.Biome;
-import org.spout.api.geo.LoadGenerateOption;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.Region;
@@ -268,113 +268,78 @@ public final class SpoutWorld extends AsyncManager implements World {
 
 	@Override
 	public SpoutRegion getRegion(int x, int y, int z) {
-		return regions.getRegion(x, y, z);
+		return getRegion(x, y, z, LoadOption.LOAD_GEN);
 	}
 
 	@Override
-	public SpoutRegion getRegion(int x, int y, int z, boolean load) {
-		return regions.getRegion(x, y, z, load ? LoadGenerateOption.LOAD_OR_GENERATE_IF_NEEDED : LoadGenerateOption.NO_LOAD);
-	}
-
-	@Override
-	public SpoutRegion getRegion(int x, int y, int z, LoadGenerateOption loadopt) {
+	public SpoutRegion getRegion(int x, int y, int z, LoadOption loadopt) {
 		return regions.getRegion(x, y, z, loadopt);
 	}
 
 	@Override
-	public SpoutRegion getRegionFromBlock(int x, int y, int z) {
-		return this.regions.getRegionFromBlock(x, y, z);
+	public SpoutRegion getRegionFromChunk(int x, int y, int z) {
+		return getRegionFromChunk(x, y, z, LoadOption.LOAD_GEN);
 	}
 
 	@Override
-	public SpoutRegion getRegionFromBlock(int x, int y, int z, boolean load) {
-		return this.regions.getRegionFromBlock(x, y, z, load ? LoadGenerateOption.LOAD_OR_GENERATE_IF_NEEDED : LoadGenerateOption.NO_LOAD);
-	}
-
-	@Override
-	public SpoutRegion getRegionFromBlock(int x, int y, int z, LoadGenerateOption loadopt) {
-		return this.regions.getRegionFromBlock(x, y, z, loadopt);
+	public SpoutRegion getRegionFromChunk(int x, int y, int z, LoadOption loadopt) {
+		return getRegion(x >> Region.CHUNKS.BITS, y >> Region.CHUNKS.BITS, z >> Region.CHUNKS.BITS, loadopt);
 	}
 
 	@Override
 	public SpoutRegion getRegionFromBlock(Vector3 position) {
-		int x = MathHelper.floor(position.getX());
-		int y = MathHelper.floor(position.getY());
-		int z = MathHelper.floor(position.getZ());
-		return regions.getRegionFromBlock(x, y, z);
+		return getRegionFromBlock(position, LoadOption.LOAD_GEN);
 	}
 
 	@Override
-	public SpoutRegion getRegionFromBlock(Vector3 position, boolean load) {
-		int x = MathHelper.floor(position.getX());
-		int y = MathHelper.floor(position.getY());
-		int z = MathHelper.floor(position.getZ());
-		return regions.getRegionFromBlock(x, y, z, load ? LoadGenerateOption.LOAD_OR_GENERATE_IF_NEEDED : LoadGenerateOption.NO_LOAD);
+	public SpoutRegion getRegionFromBlock(Vector3 position, LoadOption loadopt) {
+		return this.getRegionFromBlock(position.getFloorX(), position.getFloorY(), position.getFloorZ(), loadopt);
 	}
 
 	@Override
-	public SpoutRegion getRegionFromBlock(Vector3 position, LoadGenerateOption loadopt) {
-		int x = MathHelper.floor(position.getX());
-		int y = MathHelper.floor(position.getY());
-		int z = MathHelper.floor(position.getZ());
-		return regions.getRegionFromBlock(x, y, z, loadopt);
+	public SpoutRegion getRegionFromBlock(int x, int y, int z) {
+		return getRegionFromBlock(x, y, z, LoadOption.LOAD_GEN);
+	}
+
+	@Override
+	public SpoutRegion getRegionFromBlock(int x, int y, int z, LoadOption loadopt) {
+		return getRegion(x >> Region.BLOCKS.BITS, y >> Region.BLOCKS.BITS, z >> Region.BLOCKS.BITS, loadopt);
 	}
 
 	@Override
 	public SpoutChunk getChunk(int x, int y, int z) {
-		return this.getChunk(x, y, z, true);
+		return this.getChunk(x, y, z, LoadOption.LOAD_GEN);
 	}
 
 	@Override
-	public SpoutChunk getChunk(int x, int y, int z, boolean load) {
-		return this.getChunk(x, y, z, load ? LoadGenerateOption.LOAD_OR_GENERATE_IF_NEEDED : LoadGenerateOption.NO_LOAD);
-	}
-
-	@Override
-	public SpoutChunk getChunk(int x, int y, int z, LoadGenerateOption loadopt) {
-		SpoutRegion region = getRegion(x >> Region.REGION_SIZE_BITS, y >> Region.REGION_SIZE_BITS, z >> Region.REGION_SIZE_BITS, loadopt);
+	public SpoutChunk getChunk(int x, int y, int z, LoadOption loadopt) {
+		SpoutRegion region = getRegionFromChunk(x, y, z, loadopt);
 		if (region != null) {
-			return region.getChunk(x & Region.REGION_SIZE - 1, y & Region.REGION_SIZE - 1, z & Region.REGION_SIZE - 1, loadopt);
+			return region.getChunk(x, y, z, loadopt);
 		}
 		return null;
 	}
 
 	@Override
 	public SpoutChunk getChunkFromBlock(int x, int y, int z) {
-		return this.getChunkFromBlock(x, y, z, true);
+		return this.getChunkFromBlock(x, y, z, LoadOption.LOAD_GEN);
 	}
 
 	@Override
-	public SpoutChunk getChunkFromBlock(int x, int y, int z, boolean load) {
-		return this.getChunk(x >> Chunk.CHUNK_SIZE_BITS, y >> Chunk.CHUNK_SIZE_BITS, z >> Chunk.CHUNK_SIZE_BITS, load);
-	}
-
-	@Override
-	public SpoutChunk getChunkFromBlock(int x, int y, int z, LoadGenerateOption loadopt) {
-		return this.getChunk(x >> Chunk.CHUNK_SIZE_BITS, y >> Chunk.CHUNK_SIZE_BITS, z >> Chunk.CHUNK_SIZE_BITS, loadopt);
+	public SpoutChunk getChunkFromBlock(int x, int y, int z, LoadOption loadopt) {
+		return this.getChunk(x >> Chunk.BLOCKS.BITS, y >> Chunk.BLOCKS.BITS, z >> Chunk.BLOCKS.BITS, loadopt);
 	}
 
 	@Override
 	public SpoutChunk getChunkFromBlock(Vector3 position) {
-		return this.getChunkFromBlock(position, true);
+		return this.getChunkFromBlock(position, LoadOption.LOAD_GEN);
 	}
 
 	@Override
-	public SpoutChunk getChunkFromBlock(Vector3 position, boolean load) {
-		int x = MathHelper.floor(position.getX());
-		int y = MathHelper.floor(position.getY());
-		int z = MathHelper.floor(position.getZ());
-		return this.getChunkFromBlock(x, y, z, load);
+	public SpoutChunk getChunkFromBlock(Vector3 position, LoadOption loadopt) {
+		return this.getChunkFromBlock(position.getFloorX(), position.getFloorY(), position.getFloorZ(), loadopt);
 	}
 
-	@Override
-	public SpoutChunk getChunkFromBlock(Vector3 position, LoadGenerateOption loadopt) {
-		int x = MathHelper.floor(position.getX());
-		int y = MathHelper.floor(position.getY());
-		int z = MathHelper.floor(position.getZ());
-		return this.getChunkFromBlock(x, y, z, loadopt);
-	}
-	
 	@Override
 	public Biome getBiomeType(int x, int y, int z) {
 		if (y < 0 || y > getHeight()) {
@@ -421,7 +386,7 @@ public final class SpoutWorld extends AsyncManager implements World {
 	public Entity createAndSpawnEntity(Point point, Controller controller) {
 		Entity e = createEntity(point, controller);
 		//initialize region if needed
-		this.getRegionFromBlock(point, true);
+		this.getRegionFromBlock(point);
 		spawnEntity(e);
 		return e;
 	}
@@ -462,6 +427,16 @@ public final class SpoutWorld extends AsyncManager implements World {
 	@Override
 	public void haltRun() throws InterruptedException {
 		// TODO - save on halt ?
+	}
+
+	@Override
+	public boolean containsBlock(int x, int y, int z) {
+		return true;
+	}
+
+	@Override
+	public boolean containsChunk(int x, int y, int z) {
+		return true;
 	}
 
 	@Override
@@ -545,27 +520,27 @@ public final class SpoutWorld extends AsyncManager implements World {
 
 	@Override
 	public void updateBlockPhysics(int x, int y, int z, Source source) {
-		regions.getRegionFromBlock(x, y, z).updateBlockPhysics(x, y, z, source);
+		this.getRegionFromBlock(x, y, z).updateBlockPhysics(x, y, z, source);
 	}
 
 	@Override
 	public void resetDynamicBlock(int x, int y, int z) {
-		regions.getRegionFromBlock(x, y, z).resetDynamicBlock(x, y, z);
+		this.getRegionFromBlock(x, y, z).resetDynamicBlock(x, y, z);
 	}
-	
+
 	@Override
 	public void queueDynamicUpdate(int x, int y, int z, long nextUpdate, Object hint) {
-		regions.getRegionFromBlock(x, y, z).queueDynamicUpdate(x, y, z, nextUpdate, hint);
+		this.getRegionFromBlock(x, y, z).queueDynamicUpdate(x, y, z, nextUpdate, hint);
 	}
 
 	@Override
 	public void queueDynamicUpdate(int x, int y, int z, long nextUpdate) {
-		regions.getRegionFromBlock(x, y, z).queueDynamicUpdate(x, y, z, nextUpdate);
+		this.getRegionFromBlock(x, y, z).queueDynamicUpdate(x, y, z, nextUpdate);
 	}
 
 	@Override
 	public void queueDynamicUpdate(int x, int y, int z) {
-		regions.getRegionFromBlock(x, y, z).queueDynamicUpdate(x, y, z);
+		this.getRegionFromBlock(x, y, z).queueDynamicUpdate(x, y, z);
 	}
 	
 	@Override
@@ -706,8 +681,8 @@ public final class SpoutWorld extends AsyncManager implements World {
 	 * @return the column or null if it doesn't exist
 	 */
 	public SpoutColumn getColumn(int x, int z, boolean create) {
-		int colX = x >> SpoutColumn.COLUMN_SIZE_BITS;
-		int colZ = z >> SpoutColumn.COLUMN_SIZE_BITS;
+		int colX = x >> SpoutColumn.BLOCKS.BITS;
+		int colZ = z >> SpoutColumn.BLOCKS.BITS;
 		long key = IntPairHashed.key(colX, colZ);
 		SpoutColumn column = columns.get(key);
 		if (create && column == null) {
@@ -725,8 +700,8 @@ public final class SpoutWorld extends AsyncManager implements World {
 	}
 
 	private BAAWrapper getColumnHeightMapBAA(int x, int z) {
-		int cx = x >> Region.REGION_SIZE_BITS;
-		int cz = z >> Region.REGION_SIZE_BITS;
+		int cx = x >> Region.CHUNKS.BITS;
+		int cz = z >> Region.CHUNKS.BITS;
 
 		BAAWrapper baa = null;
 
@@ -813,27 +788,27 @@ public final class SpoutWorld extends AsyncManager implements World {
 
 	@Override
 	public boolean hasChunk(int x, int y, int z) {
-		return this.getChunk(x, y, z, false) != null;
+		return this.getChunk(x, y, z, LoadOption.NO_LOAD) != null;
 	}
 
 	@Override
 	public boolean hasChunkAtBlock(int x, int y, int z) {
-		return this.getChunkFromBlock(x, y, z, false) != null;
+		return this.getChunkFromBlock(x, y, z, LoadOption.NO_LOAD) != null;
 	}
 
 	@Override
 	public void saveChunk(int x, int y, int z) {
-		SpoutRegion r = this.getRegion(x >> Region.REGION_SIZE_BITS, y >> Region.REGION_SIZE_BITS, z >> Region.REGION_SIZE_BITS, false);
+		SpoutRegion r = this.getRegionFromChunk(x, y, z, LoadOption.NO_LOAD);
 		if (r != null) {
-			r.saveChunk(x & Region.REGION_SIZE - 1, y & Region.REGION_SIZE - 1, z & Region.REGION_SIZE - 1);
+			r.saveChunk(x, y, z);
 		}
 	}
 
 	@Override
 	public void unloadChunk(int x, int y, int z, boolean save) {
-		SpoutRegion r = this.getRegion(x >> Region.REGION_SIZE_BITS, y >> Region.REGION_SIZE_BITS, z >> Region.REGION_SIZE_BITS, false);
+		SpoutRegion r = this.getRegionFromChunk(x, y, z, LoadOption.NO_LOAD);
 		if (r != null) {
-			r.unloadChunk(x & Region.REGION_SIZE - 1, y & Region.REGION_SIZE - 1, z & Region.REGION_SIZE - 1, save);
+			r.unloadChunk(x, y, z, save);
 		}
 	}
 
@@ -946,16 +921,15 @@ public final class SpoutWorld extends AsyncManager implements World {
 	 * @return nearby region's players
 	 */
 	private Set<Player> getPlayersNearRegion(Point position, int range) {
-		final int REGION_SIZE = Region.REGION_SIZE * Chunk.CHUNK_SIZE;
 		Region center = this.getRegionFromBlock(position);
 
 		if (center != null) {
 			HashSet<Player> players = new HashSet<Player>();
-			final int regions = (range + REGION_SIZE - 1) / REGION_SIZE; //round up 1 region size
+			final int regions = (range + Region.BLOCKS.SIZE - 1) / Region.BLOCKS.SIZE; //round up 1 region size
 			for (int dx = -regions; dx < regions; dx++) {
 				for (int dy = -regions; dy < regions; dy++) {
 					for (int dz = -regions; dz < regions; dz++) {
-						Region region = this.getRegion(center.getX() + dx, center.getY() + dy, center.getZ() + dz, false);
+						Region region = this.getRegion(center.getX() + dx, center.getY() + dy, center.getZ() + dz, LoadOption.NO_LOAD);
 						if (region != null) {
 							players.addAll(region.getPlayers());
 						}

--- a/src/main/java/org/spout/engine/world/SpoutWorldLightingModel.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorldLightingModel.java
@@ -27,6 +27,7 @@
 package org.spout.engine.world;
 
 import org.spout.api.Spout;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFace;
 import org.spout.api.material.block.BlockFaces;
@@ -82,6 +83,13 @@ public class SpoutWorldLightingModel {
 		for (int i = 0; i < this.neighbors.length; i++) {
 			BlockFace face = BlockFaces.NESWBT.get(i);
 			this.neighbors[i] = sky ? new SkyElement(world, face, this.center) : new BlockElement(world, face, this.center);
+		}
+	}
+
+	public void addRefresh(SpoutChunk chunk, int x, int y, int z) {
+		BlockMaterial mat = chunk.getBlockMaterial(x, y, z).getSubMaterial(chunk.getBlockData(x, y, z));
+		if (!mat.getOcclusion().get(BlockFaces.NESWBT)) {
+			this.addRefresh(x, y, z);
 		}
 	}
 
@@ -383,7 +391,7 @@ public class SpoutWorldLightingModel {
 			if (center.chunk != null && center.chunk.isLoaded() && center.chunk.containsBlock(this.x, this.y, this.z)) {
 				this.chunk = center.chunk;
 			} else {
-				this.chunk = this.world.getChunkFromBlock(this.x, this.y, this.z, false);
+				this.chunk = this.world.getChunkFromBlock(this.x, this.y, this.z, LoadOption.NO_LOAD);
 			}
 			if (this.chunk == null || !this.chunk.isLoaded()) {
 				this.material = null;

--- a/src/main/java/org/spout/engine/world/dynamic/DynamicBlockUpdate.java
+++ b/src/main/java/org/spout/engine/world/dynamic/DynamicBlockUpdate.java
@@ -33,9 +33,6 @@ import org.spout.api.util.hashing.ByteTripleHashed;
 
 public class DynamicBlockUpdate implements Comparable<DynamicBlockUpdate> {
 
-	private static final int chunkMask = Region.REGION_SIZE - 1;
-	private static final int regionMask = (Region.REGION_SIZE * Chunk.CHUNK_SIZE) - 1;
-
 	private final int packed;
 	private final int chunkPacked;
 	private final long nextUpdate;
@@ -49,11 +46,11 @@ public class DynamicBlockUpdate implements Comparable<DynamicBlockUpdate> {
 	}
 
 	public DynamicBlockUpdate(int x, int y, int z, long nextUpdate, long lastUpdate, Object hint) {
-		x &= regionMask;
-		y &= regionMask;
-		z &= regionMask;
+		x &= Region.BLOCKS.MASK;
+		y &= Region.BLOCKS.MASK;
+		z &= Region.BLOCKS.MASK;
 		this.packed = getBlockPacked(x, y, z);
-		this.chunkPacked = ByteTripleHashed.key(x >> Chunk.CHUNK_SIZE_BITS, y >> Chunk.CHUNK_SIZE_BITS, z >> Chunk.CHUNK_SIZE_BITS);
+		this.chunkPacked = ByteTripleHashed.key(x >> Chunk.BLOCKS.BITS, y >> Chunk.BLOCKS.BITS, z >> Chunk.BLOCKS.BITS);
 		this.nextUpdate = nextUpdate;
 		this.lastUpdate = lastUpdate;
 		this.hint = hint;
@@ -92,12 +89,12 @@ public class DynamicBlockUpdate implements Comparable<DynamicBlockUpdate> {
 	}
 
 	public boolean isInChunk(Chunk c) {
-		int cx = c.getX() & chunkMask;
-		int cy = c.getY() & chunkMask;
-		int cz = c.getZ() & chunkMask;
-		int bxShift = getX() >> Chunk.CHUNK_SIZE_BITS;
-		int byShift = getY() >> Chunk.CHUNK_SIZE_BITS;
-		int bzShift = getZ() >> Chunk.CHUNK_SIZE_BITS;
+		int cx = c.getX() & Region.CHUNKS.MASK;
+		int cy = c.getY() & Region.CHUNKS.MASK;
+		int cz = c.getZ() & Region.CHUNKS.MASK;
+		int bxShift = getX() >> Chunk.BLOCKS.BITS;
+		int byShift = getY() >> Chunk.BLOCKS.BITS;
+		int bzShift = getZ() >> Chunk.BLOCKS.BITS;
 		return cx == bxShift && cy == byShift && cz == bzShift;
 	}
 
@@ -194,17 +191,11 @@ public class DynamicBlockUpdate implements Comparable<DynamicBlockUpdate> {
 	}
 		
 	public static int getBlockPacked(int x, int y, int z) {
-		x &= regionMask;
-		y &= regionMask;
-		z &= regionMask;
-		return ByteTripleHashed.key(x, y, z);
+		return ByteTripleHashed.key(x & Region.BLOCKS.MASK, y & Region.BLOCKS.MASK, z & Region.BLOCKS.MASK);
 	}
 
 	public static int getChunkPacked(Chunk c) {
-		int cx = c.getX() & chunkMask;
-		int cy = c.getY() & chunkMask;
-		int cz = c.getZ() & chunkMask;
-		return ByteTripleHashed.key(cx, cy, cz);
+		return ByteTripleHashed.key(c.getX() & Chunk.BLOCKS.MASK, c.getY() & Chunk.BLOCKS.MASK, c.getZ() & Chunk.BLOCKS.MASK);
 	}
 
 	public static int unpackX(int packed) {
@@ -218,5 +209,4 @@ public class DynamicBlockUpdate implements Comparable<DynamicBlockUpdate> {
 	public static int unpackZ(int packed) {
 		return ByteTripleHashed.key3(packed);
 	}
-
 }


### PR DESCRIPTION
Now doesn't schedule a block for lighting if it is solid. Makes a significant difference. Also added an override for the new functions in spoutAPI.

It now uses the new constants and here and there fixed some things, as well added a lot of functions to get chunks by block and etc.

https://github.com/SpoutDev/SpoutAPI/pull/241
https://github.com/VanillaDev/Vanilla/pull/229
