### PR TITLE
Made some lighting optimizations

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -317,21 +317,13 @@ public class SpoutChunk extends Chunk {
 				for (y = newheight; y < oldheight; y++) {
 					world.setBlockSkyLight(x, y + 1, z, (byte) 15, source);
 				}
-			} else if (!this.setBlockSkyLight(x, y, z, (byte) 0, source)) {
-				// if the light level is left unchanged, refresh lighting from neighbors
-				world.getLightingManager().skyLight.addRefresh(x, y, z);
 			} else {
-				// This was previously used instead of the three lines above
-				// It is a possible cause for bugged lighting
-				// Keep it, as it did solve a problem with wrongly-cleared blocks (dark chunks)
-				/*
 				byte old = this.getBlockSkyLight(x, y, z);
 				if (old == 0) {
 					world.getLightingManager().skyLight.addRefresh(this, x, y, z);
 				} else if (old < 15) {
 					this.setBlockSkyLight(x, y, z, (byte) 0, source);
 				}
-				 */
 			}
 		}
 		if (material instanceof DynamicMaterial) {
@@ -867,7 +859,7 @@ public class SpoutChunk extends Chunk {
 			for (y = 0; y < BLOCKS.SIZE; y++) {
 				for (z = 0; z < BLOCKS.SIZE; z++) {
 					if (!this.setBlockLight(x, y, z, this.getBlockMaterial(x, y, z).getLightLevel(this.getBlockData(x, y, z)), world)) {
-						// Failing?
+						// Bugged?
 						//world.getLightingManager().blockLight.addRefresh(this, x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ());
 					}
 				}
@@ -889,13 +881,12 @@ public class SpoutChunk extends Chunk {
 					this.setBlockSkyLight(x, y, z, (byte) 15, world);
 				}
 				// refresh area below height
-				// This is a possible cause for bugged light
-				// It does offer fixes, but just in case, it is commented out
+				// Bugged?
 				/*
 				for (y = columnY; y >= minY; y--) {
 					world.getLightingManager().skyLight.addRefresh(this, x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ());
 				}
-				 */
+				*/
 			}
 		}
 	}

--- a/src/main/java/org/spout/engine/world/SpoutWorldLightingModel.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorldLightingModel.java
@@ -87,13 +87,9 @@ public class SpoutWorldLightingModel {
 	}
 
 	public void addRefresh(SpoutChunk chunk, int x, int y, int z) {
-		this.addRefresh(x, y, z);
-		// Fail?
-		/*
 		if (!chunk.getBlockMaterial(x, y, z).getOcclusion().get(BlockFaces.NESWBT)) {
 			this.addRefresh(x, y, z);
 		}
-		*/
 	}
 
 	public void addRefresh(int x, int y, int z) {
@@ -255,9 +251,6 @@ public class SpoutWorldLightingModel {
 	 * @return True if it was successful
 	 */
 	public boolean loadReceive(int x, int y, int z) {
-		return this.loadSend(x, y, z);
-		// Fail?
-		/*
 		this.center.load(x, y, z);
 		if (this.center.material == null || this.center.material.getOcclusion().get(BlockFaces.NESWBT)) {
 			return false;
@@ -270,7 +263,6 @@ public class SpoutWorldLightingModel {
 			}
 		}
 		return true;
-		*/
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

Two bits in SpoutChunk.initLighting are commented out because they appeared to have caused lighting to get out of sync. This can have to do with how the 'refresh' handling functions, or some sort of rare case where it overwrites proper lighting because it is not synchronized.
