### PR TITLE
Moved light storage to chunks

### DIFF
--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -37,7 +37,6 @@ import org.spout.api.datatable.DatatableMap;
 import org.spout.api.generator.biome.BiomeManager;
 import org.spout.api.geo.cuboid.ChunkSnapshot;
 import org.spout.api.material.BlockMaterial;
-import org.spout.api.material.block.BlockFullState;
 import org.spout.api.math.Vector3;
 import org.spout.api.util.map.concurrent.AtomicBlockStoreImpl;
 import org.spout.engine.filesystem.WorldFiles;
@@ -89,7 +88,7 @@ public class FilteredChunk extends SpoutChunk{
 			this.blockStore = new AtomicBlockStoreImpl(BLOCKS.BITS, 10, initial);
 			
 			this.skyLight = new byte[BLOCKS.HALF_VOLUME];
-			System.arraycopy(this.getY() < 4 ? DARK : LIGHT, 0, this.skyLight, 0, this.skyLight.length);
+			System.arraycopy(this.isAboveGround() ? LIGHT : DARK, 0, this.skyLight, 0, this.skyLight.length);
 			
 			this.blockLight = new byte[BLOCKS.HALF_VOLUME];
 			System.arraycopy(DARK, 0, this.blockLight, 0, this.blockLight.length);
@@ -102,6 +101,10 @@ public class FilteredChunk extends SpoutChunk{
 		return uniform.get();
 	}
 
+	public boolean isAboveGround() {
+		return this.getY() >= 4;
+	}
+	
 	@Override
 	public boolean setBlockData(int x, int y, int z, short data, Source source) {
 		if (uniform.get()) {
@@ -117,7 +120,7 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.setBlockMaterial(x, y, z, material, data, source);
 	}
-	
+
 	@Override
 	public BlockMaterial getBlockMaterial(int x, int y, int z) {
 		if (uniform.get()) {
@@ -125,7 +128,7 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.getBlockMaterial(x, y, z);
 	}
-	
+
 	@Override
 	public short getBlockData(int x, int y, int z) {
 		if (uniform.get()) {
@@ -133,7 +136,7 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.getBlockData(x, y, z);
 	}
-	
+
 	@Override
 	public boolean compareAndSetData(int x, int y, int z, int expect, short data) {
 		if (uniform.get()) {
@@ -141,7 +144,7 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.compareAndSetData(x, y, z, expect, data);
 	}
-	
+
 	@Override
 	public boolean setBlockLight(int x, int y, int z, byte light, Source source) {
 		if (uniform.get()) {
@@ -149,7 +152,7 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.setBlockLight(x, y, z, light, source);
 	}
-	
+
 	@Override
 	public boolean setBlockSkyLight(int x, int y, int z, byte light, Source source) {
 		if (uniform.get()) {
@@ -157,19 +160,19 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.setBlockSkyLight(x, y, z, light, source);
 	}
-	
+
 	@Override
 	public byte getBlockSkyLight(int x, int y, int z) {
 		if (uniform.get()) {
-			return 0xF;
+			return this.isAboveGround() ? (byte) 0xF : (byte) 0x0;
 		}
 		return super.getBlockSkyLight(x, y, z);
 	}
-	
+
 	@Override
 	public byte getBlockLight(int x, int y, int z) {
 		if (uniform.get()) {
-			return 0xF;
+			return material.get().getLightLevel((short) 0);
 		}
 		return super.getBlockLight(x, y, z);
 	}
@@ -194,7 +197,7 @@ public class FilteredChunk extends SpoutChunk{
 			super.syncSave();
 		}
 	}
-	
+
 	@Override
 	public ChunkSnapshot getSnapshot(boolean entities) {
 		if (uniform.get()) {
@@ -213,7 +216,7 @@ public class FilteredChunk extends SpoutChunk{
 		}
 		return super.getSnapshot(entities);
 	}
-	
+
 	@Override
 	public boolean compressIfRequired() {
 		if (uniform.get()) {

--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -73,6 +73,7 @@ import org.spout.api.util.cuboid.CuboidBuffer;
 import org.spout.api.util.hashing.NibblePairHashed;
 import org.spout.api.util.map.concurrent.AtomicBlockStore;
 import org.spout.api.util.map.concurrent.AtomicBlockStoreImpl;
+import org.spout.api.util.set.TNibbleQuadHashSet;
 import org.spout.engine.SpoutConfiguration;
 import org.spout.engine.SpoutEngine;
 import org.spout.engine.entity.SpoutEntity;
@@ -153,7 +154,14 @@ public class SpoutChunk extends Chunk {
 	 * increment it as well.
 	 */
 	protected final AtomicInteger lightingCounter = new AtomicInteger(-1);
-
+	/**
+	 * Contains the pending block light operations of blocks in this chunk
+	 */
+	protected final TNibbleQuadHashSet blockLightOperations = new TNibbleQuadHashSet();
+	/**
+	 * Contains the pending sky light operations of blocks in this chunk
+	 */
+	protected final TNibbleQuadHashSet skyLightOperations = new TNibbleQuadHashSet();
 	/**
 	 * Indicates if there has been any changes since the last render snapshot
 	 */
@@ -321,7 +329,7 @@ public class SpoutChunk extends Chunk {
 			if (!this.setBlockLight(x, y, z, material.getLightLevel(data), source)) {
 				// if the light level is left unchanged, refresh lighting from
 				// neighbors
-				world.getLightingManager().blockLight.addRefresh(x, y, z);
+				addBlockLightOperation(x, y, z, SpoutWorldLighting.REFRESH);
 			}
 
 			// Update sky lighting
@@ -338,7 +346,7 @@ public class SpoutChunk extends Chunk {
 			} else {
 				byte old = this.getBlockSkyLight(x, y, z);
 				if (old == 0) {
-					world.getLightingManager().skyLight.addRefresh(this, x, y, z);
+					addSkyLightOperation(x, y, z, SpoutWorldLighting.REFRESH);
 				} else if (old < 15) {
 					this.setBlockSkyLight(x, y, z, (byte) 0, source);
 				}
@@ -355,6 +363,46 @@ public class SpoutChunk extends Chunk {
 			}
 		}
 		return true;
+	}
+
+	protected void addSkyLightOperation(int x, int y, int z, int operation) {
+		SpoutWorldLightingModel model = this.getWorld().getLightingManager().skyLight;
+		if (operation == SpoutWorldLighting.REFRESH) {
+			if (!model.canRefresh(this, x, y, z)) {
+				return;
+			}
+		} else if (operation == SpoutWorldLighting.GREATER) {
+			if (!model.canGreater(this, x, y, z)) {
+				return;
+			}
+		}
+		synchronized (this.skyLightOperations) {
+			if (this.skyLightOperations.isEmpty()) {
+				// Let the lighting manager know this chunk requires a lighting update
+				this.getWorld().getLightingManager().addChunk(this.getX(), this.getY(), this.getZ());
+			}
+			this.skyLightOperations.add(x & BLOCKS.MASK, y & BLOCKS.MASK, z & BLOCKS.MASK, operation);
+		}
+	}
+
+	protected void addBlockLightOperation(int x, int y, int z, int operation) {
+		SpoutWorldLightingModel model = this.getWorld().getLightingManager().blockLight;
+		if (operation == SpoutWorldLighting.REFRESH) {
+			if (!model.canRefresh(this, x, y, z)) {
+				return;
+			}
+		} else if (operation == SpoutWorldLighting.GREATER) {
+			if (!model.canGreater(this, x, y, z)) {
+				return;
+			}
+		}
+		synchronized (this.blockLightOperations) {
+			if (this.blockLightOperations.isEmpty()) {
+				// Let the lighting manager know this chunk requires a lighting update
+				this.getWorld().getLightingManager().addChunk(this.getX(), this.getY(), this.getZ());
+			}
+			this.blockLightOperations.add(x & BLOCKS.MASK, y & BLOCKS.MASK, z & BLOCKS.MASK, operation);
+		}
 	}
 
 	protected void setCuboid(CuboidBuffer buffer) {
@@ -386,7 +434,7 @@ public class SpoutChunk extends Chunk {
 	public void resetDynamicBlock(int x, int y, int z) {
 		parentRegion.resetDynamicBlock(getBlockX(x), getBlockY(y), getBlockZ(z));
 	}
-	
+
 	@Override
 	public DynamicUpdateEntry queueDynamicUpdate(int x, int y, int z, long nextUpdate, int data, Object hint) {
 		return parentRegion.queueDynamicUpdate(getBlockX(x), getBlockY(y), getBlockZ(z), nextUpdate, data, hint);
@@ -441,20 +489,20 @@ public class SpoutChunk extends Chunk {
 		int index = getBlockIndex(x, y, z);
 		byte oldLight;
 		if ((index & 1) == 1) {
-			index >>= 1;
+			index = index >> 1;
 			oldLight = NibblePairHashed.key1(blockLight[index]);
 			blockLight[index] = NibblePairHashed.setKey1(blockLight[index], light);
 		} else {
-			index >>= 1;
+			index = index >> 1;
 			oldLight = NibblePairHashed.key2(blockLight[index]);
 			blockLight[index] = NibblePairHashed.setKey2(blockLight[index], light);
 		}
 		if (light > oldLight) {
 			// light increased
-			getWorld().getLightingManager().blockLight.addGreater(x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ());
+			this.addBlockLightOperation(x, y, z, SpoutWorldLighting.GREATER);
 		} else if (light < oldLight) {
 			// light decreased
-			getWorld().getLightingManager().blockLight.addLesser(x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ());
+			this.addBlockLightOperation(x, y, z, SpoutWorldLighting.LESSER);
 		} else {
 			return false;
 		}
@@ -488,21 +536,21 @@ public class SpoutChunk extends Chunk {
 		int index = getBlockIndex(x, y, z);
 		byte oldLight;
 		if ((index & 1) == 1) {
-			index >>= 1;
+			index = index >> 1;
 			oldLight = NibblePairHashed.key1(skyLight[index]);
 			skyLight[index] = NibblePairHashed.setKey1(skyLight[index], light);
 		} else {
-			index >>= 1;
+			index = index >> 1;
 			oldLight = NibblePairHashed.key2(skyLight[index]);
 			skyLight[index] = NibblePairHashed.setKey2(skyLight[index], light);
 		}
 
 		if (light > oldLight) {
 			// light increased
-			getWorld().getLightingManager().skyLight.addGreater(x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ());
+			this.addSkyLightOperation(x, y, z, SpoutWorldLighting.GREATER);
 		} else if (light < oldLight) {
 			// light decreased
-			getWorld().getLightingManager().skyLight.addLesser(x + this.getBlockX(), y + this.getBlockY(), z + this.getBlockZ());
+			this.addSkyLightOperation(x, y, z, SpoutWorldLighting.LESSER);
 		} else {
 			return false;
 		}
@@ -623,23 +671,23 @@ public class SpoutChunk extends Chunk {
 			SaveState state = saveState.get();
 			SaveState nextState;
 			switch (state) {
-			case UNLOAD_SAVE:
-				nextState = SaveState.UNLOAD_SAVE;
-				break;
-			case UNLOAD:
-				nextState = SaveState.UNLOAD_SAVE;
-				break;
-			case SAVE:
-				nextState = SaveState.SAVE;
-				break;
-			case NONE:
-				nextState = SaveState.SAVE;
-				break;
-			case UNLOADED:
-				nextState = SaveState.UNLOADED;
-				break;
-			default:
-				throw new IllegalStateException("Unknown save state: " + state);
+				case UNLOAD_SAVE:
+					nextState = SaveState.UNLOAD_SAVE;
+					break;
+				case UNLOAD:
+					nextState = SaveState.UNLOAD_SAVE;
+					break;
+				case SAVE:
+					nextState = SaveState.SAVE;
+					break;
+				case NONE:
+					nextState = SaveState.SAVE;
+					break;
+				case UNLOADED:
+					nextState = SaveState.UNLOADED;
+					break;
+				default:
+					throw new IllegalStateException("Unknown save state: " + state);
 			}
 			success = saveState.compareAndSet(state, nextState);
 		}
@@ -948,10 +996,7 @@ public class SpoutChunk extends Chunk {
 			for (y = 0; y < BLOCKS.SIZE; y++) {
 				for (z = 0; z < BLOCKS.SIZE; z++) {
 					if (!this.setBlockLight(x, y, z, this.getBlockMaterial(x, y, z).getLightLevel(this.getBlockData(x, y, z)), world)) {
-						// Bugged? This requires additional testing!
-						// world.getLightingManager().blockLight.addRefresh(this,
-						// x + this.getBlockX(), y + this.getBlockY(), z +
-						// this.getBlockZ());
+						this.addBlockLightOperation(x, y, z, SpoutWorldLighting.REFRESH);
 					}
 				}
 			}
@@ -971,13 +1016,11 @@ public class SpoutChunk extends Chunk {
 				for (y = columnY; y < maxY; y++) {
 					this.setBlockSkyLight(x, y, z, (byte) 15, world);
 				}
-				// Bugged? This requires additional testing!
-				/*
-				 * // refresh area below height for (y = columnY; y >= minY;
-				 * y--) { world.getLightingManager().skyLight.addRefresh(this, x
-				 * + this.getBlockX(), y + this.getBlockY(), z +
-				 * this.getBlockZ()); }
-				 */
+
+				// refresh area below height 
+				for (y = columnY; y >= minY; y--) {
+					this.addSkyLightOperation(x, y, z, SpoutWorldLighting.REFRESH);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

To cut memory usage, it will now store all block lighting operations (sky/block) in the chunk, instead of using 6 Int21 hashmaps in the lighting models.

Benefits:
- Less memory usage in the long run
- Faster to schedule new updates (long key and hashcode generation was very slow)
- Faster to clear previous updates (<4K to clean up, a lot faster than millions)
- Less high buffers
- Per-chunk operating to prevent conflicts while chunks are generating
