### PR TITLE
Reduced the amount of lighting refreshes

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
@@ -113,9 +113,14 @@ public class SpoutWorldLighting extends Thread implements Source {
 						cz = Int21TripleHashed.key3(chunkBuffer[i]);
 						chunk = this.world.getChunk(cx, cy, cz, LoadOption.LOAD_ONLY);
 						if (chunk != null && chunk.isLoaded() && chunk.isPopulated()) {
-							// Resolve all the operations in this chunk
-							while (this.blockLight.resolve(chunk));
-							while (this.skyLight.resolve(chunk));
+							if (chunk.isInitializingLighting.get()) {
+								// Schedule the chunk for a later check-up
+								this.addChunk(cx, cy, cz);
+							} else {
+								// Resolve all the operations in this chunk
+								while (this.blockLight.resolve(chunk));
+								while (this.skyLight.resolve(chunk));
+							}
 						}
 					}
 					idleCounter = 0;


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

When initializing lighting, it no longer refreshes blocks inside the 13_13_13 area of the chunk. Greater-than operations should take care of that, otherwise the edges would update from nearby chunks.
