### PR TITLE
Added populator clearance

### DIFF
--- a/src/main/java/org/spout/engine/MemoryLeakThread.java
+++ b/src/main/java/org/spout/engine/MemoryLeakThread.java
@@ -119,7 +119,7 @@ public class MemoryLeakThread extends Thread {
 
 								if (passes > LEAK_PASSES) {
 									Spout.getLogger().severe("Chunk is leaking memory! Chunk is " + chunk.toString() + ":" + ((SpoutChunk)chunk).getSaveState());
-									if (chunk.getRegion() != null && chunk.getRegion().getChunk(chunk.getX(), chunk.getY(), chunk.getZ()) == chunk) {
+									if (chunk.getRegion() != null && chunk.getRegion().getChunk(chunk.getX(), chunk.getY(), chunk.getZ(), LoadOption.NO_LOAD) == chunk) {
 										Spout.getLogger().severe("Chunk is still referenced by it's region! Chunk is " + chunk.toString());
 									}
 									int rx = chunk.getX() >> Region.CHUNKS.BITS;
@@ -136,7 +136,7 @@ public class MemoryLeakThread extends Thread {
 									}
 								} else if (passes > WARNING_PASSES) {
 									Spout.getLogger().warning("Chunk may be leaking memory, " + chunk.toString());
-									if (chunk.getRegion() != null && chunk.getRegion().getChunk(chunk.getX(), chunk.getY(), chunk.getZ()) == chunk) {
+									if (chunk.getRegion() != null && chunk.getRegion().getChunk(chunk.getX(), chunk.getY(), chunk.getZ(), LoadOption.NO_LOAD) == chunk) {
 										Spout.getLogger().severe("Chunk is still referenced by it's region! Chunk is " + chunk.toString());
 									}
 									int rx = chunk.getX() >> Region.CHUNKS.BITS;

--- a/src/main/java/org/spout/engine/SpoutClient.java
+++ b/src/main/java/org/spout/engine/SpoutClient.java
@@ -295,27 +295,27 @@ public class SpoutClient extends SpoutEngine implements Client {
 		//renderer.end();
 		
 		//renderer.draw();
-/*
+
 	
 		textureTest.begin(material);
-		textureTest.getShader().setUniform("View", activeCamera.getView());
+		textureTest.getShader().setUniform("View", view);
 		textureTest.getShader().setUniform("Projection", activeCamera.getProjection());
 		textureTest.addTexCoord(0, 0);
-		textureTest.addVertex(0, 0);
+		textureTest.addVertex(4, 4);
 		textureTest.addTexCoord(1, 0);
-		textureTest.addVertex(1, 0);
+		textureTest.addVertex(5, 4);
 		textureTest.addTexCoord(0, 1);
-		textureTest.addVertex(0, 1);
+		textureTest.addVertex(4, 5);
 
 		textureTest.addTexCoord(0, 1);
-		textureTest.addVertex(0, 1);
+		textureTest.addVertex(4, 5);
 		textureTest.addTexCoord(1, 1);
-		textureTest.addVertex(1, 1);
+		textureTest.addVertex(5, 5);
 		textureTest.addTexCoord(1, 0);
-		textureTest.addVertex(1, 0);
+		textureTest.addVertex(5, 4);
 		textureTest.end();
 		textureTest.render();
-		*/
+		
 		/*
 		Object[] worlds = this.getLiveWorlds().toArray();
 		SpoutWorld world = (SpoutWorld)worlds[0];

--- a/src/main/java/org/spout/engine/SpoutEngine.java
+++ b/src/main/java/org/spout/engine/SpoutEngine.java
@@ -121,6 +121,7 @@ import org.spout.engine.util.thread.snapshotable.SnapshotableReference;
 import org.spout.engine.util.thread.threadfactory.NamedThreadFactory;
 import org.spout.engine.world.SpoutRegion;
 import org.spout.engine.world.SpoutWorld;
+import org.spout.engine.world.WorldSavingThread;
 
 import com.beust.jcommander.Parameter;
 
@@ -251,6 +252,7 @@ public class SpoutEngine extends AsyncManager implements Engine {
 		}
 
 		scheduler.startMainThread();
+		WorldSavingThread.startThread();
 		setupComplete.set(true);
 	}
 
@@ -524,7 +526,7 @@ public class SpoutEngine extends AsyncManager implements Engine {
 		}
 
 		for (SpoutWorld world : this.getLiveWorlds()) {
-			world.unload(true);
+			world.unload(true, true);
 		}
 
 		getPluginManager().clearPlugins();
@@ -533,7 +535,7 @@ public class SpoutEngine extends AsyncManager implements Engine {
 		group.close();
 		bootstrapProtocols.clear();
 		executor.shutdown();
-
+		WorldSavingThread.finish();
 	}
 
 	@Override
@@ -722,7 +724,7 @@ public class SpoutEngine extends AsyncManager implements Engine {
 					throw new IllegalStateException("Executor was already halted when halting was attempted");
 				}
 				getEventManager().callDelayedEvent(new WorldUnloadEvent(world));
-				w.unload(save);
+				w.unload(save, false);
 			}
 			//Note: Worlds should not allow being saved twice and/or throw exceptions if accessed after unloading
 			//      Also, should blank out as much internal world data as possible, in case plugins retain references to unloaded worlds

--- a/src/main/java/org/spout/engine/SpoutEngine.java
+++ b/src/main/java/org/spout/engine/SpoutEngine.java
@@ -95,6 +95,8 @@ import org.spout.api.plugin.security.CommonSecurityManager;
 import org.spout.api.protocol.SessionRegistry;
 import org.spout.api.protocol.bootstrap.BootstrapProtocol;
 import org.spout.api.scheduler.TaskManager;
+import org.spout.api.scheduler.TaskPriority;
+import org.spout.api.util.Profiler;
 import org.spout.api.util.StringMap;
 import org.spout.engine.command.AdministrationCommands;
 import org.spout.engine.command.MessagingCommands;
@@ -200,6 +202,7 @@ public class SpoutEngine extends AsyncManager implements Engine {
 		if (debugMode()) {
 			getLogger().warning("Spout has been started in Debug Mode!  This mode is for developers only");
 			leakThread.start();
+			scheduler.scheduleSyncRepeatingTask(this, new ProfileTask(), 60 * 1000, 60 * 1000, TaskPriority.NORMAL);
 		}
 
 		CommandRegistrationsFactory<Class<?>> commandRegFactory = new AnnotatedCommandRegistrationFactory(new SimpleInjector(this), new SimpleAnnotatedCommandExecutorFactory());
@@ -855,5 +858,12 @@ public class SpoutEngine extends AsyncManager implements Engine {
 	public String getVariable(String key) {
 		return cvars.get(key);
 		
+	}
+	
+	private class ProfileTask implements Runnable {
+		@Override
+		public void run() {
+			Profiler.log();
+		}
 	}
 }

--- a/src/main/java/org/spout/engine/SpoutEngine.java
+++ b/src/main/java/org/spout/engine/SpoutEngine.java
@@ -866,6 +866,7 @@ public class SpoutEngine extends AsyncManager implements Engine {
 		@Override
 		public void run() {
 			Profiler.log();
+			
 		}
 	}
 }

--- a/src/main/java/org/spout/engine/batcher/PrimitiveBatch.java
+++ b/src/main/java/org/spout/engine/batcher/PrimitiveBatch.java
@@ -102,8 +102,8 @@ public class PrimitiveBatch {
 	public void addMesh(BaseMesh mesh){
 		for(ModelFace face : mesh){
 			for(Vertex vert : face){
-				//renderer.addTexCoord(vert.uv);
-				//renderer.addNormal(vert.normal);
+				renderer.addTexCoord(vert.texCoord0);
+				renderer.addNormal(vert.normal);
 				renderer.addColor(Color.red);
 				renderer.addVertex(vert.position);
 			}

--- a/src/main/java/org/spout/engine/batcher/PrimitiveBatch.java
+++ b/src/main/java/org/spout/engine/batcher/PrimitiveBatch.java
@@ -32,7 +32,7 @@ import org.lwjgl.opengl.GL11;
 
 import org.spout.api.math.Vector3;
 import org.spout.api.model.ModelFace;
-import org.spout.api.model.PositionNormalTexture;
+import org.spout.api.model.Vertex;
 import org.spout.api.render.RenderMaterial;
 import org.spout.api.render.Renderer;
 
@@ -101,7 +101,7 @@ public class PrimitiveBatch {
 	
 	public void addMesh(BaseMesh mesh){
 		for(ModelFace face : mesh){
-			for(PositionNormalTexture vert : face){
+			for(Vertex vert : face){
 				//renderer.addTexCoord(vert.uv);
 				//renderer.addNormal(vert.normal);
 				renderer.addColor(Color.red);

--- a/src/main/java/org/spout/engine/entity/SpoutEntity.java
+++ b/src/main/java/org/spout/engine/entity/SpoutEntity.java
@@ -56,6 +56,7 @@ import org.spout.api.model.Model;
 import org.spout.api.player.Player;
 import org.spout.api.tickable.Tickable;
 import org.spout.api.util.OutwardIterator;
+import org.spout.api.util.Profiler;
 import org.spout.engine.SpoutConfiguration;
 import org.spout.engine.SpoutEngine;
 import org.spout.engine.protocol.SpoutSession;
@@ -146,6 +147,7 @@ public class SpoutEntity extends Tickable implements Entity {
 
 	@Override
 	public void onTick(float dt) {
+		Profiler.start("tick entity session");
 		Controller cont = controllerLive.get();
 		//Pulse all player messages here, so they can interact with the entities position safely
 		if (cont instanceof PlayerController) {
@@ -156,6 +158,7 @@ public class SpoutEntity extends Tickable implements Entity {
 		}
 
 		//Tick the controller
+		Profiler.startAndStop("tick entity controller");
 		if (cont != null) {
 			//Sanity check
 			if (cont.getParent() != this) {
@@ -181,11 +184,13 @@ public class SpoutEntity extends Tickable implements Entity {
 		 * Copy over live chunk and entity manager values if this entity is valid. Transform copying is handled in
 		 * resolve (Tick Stage 2Pre).
 		 */
+		Profiler.startAndStop("tick entity chunk");
 		if (!isDead() && getPosition() != null && getWorld() != null) {
 			//Note: if the chunk is null, this effectively kills the entity (since dead: {chunkLive.get() == null})
 			chunkLive.set(getWorld().getChunkFromBlock(transform.getPosition(), LoadOption.NO_LOAD));
 			entityManagerLive.set(((SpoutRegion)getRegion()).getEntityManager());
 		}
+		Profiler.stop();
 	}
 
 	/**

--- a/src/main/java/org/spout/engine/entity/SpoutEntity.java
+++ b/src/main/java/org/spout/engine/entity/SpoutEntity.java
@@ -614,7 +614,7 @@ public class SpoutEntity extends Tickable implements Entity {
 		OutwardIterator oi = new OutwardIterator(cx, cy, cz, viewDistance);
 		while (oi.hasNext()) {
 			IntVector3 v = oi.next();
-			Chunk chunk = w.getChunk(v.getX(), v.getY(), v.getZ());
+			Chunk chunk = w.getChunk(v.getX(), v.getY(), v.getZ(), LoadOption.LOAD_GEN);
 			chunk.refreshObserver(this);
 			observing.add((SpoutChunk)chunk);
 		}

--- a/src/main/java/org/spout/engine/filesystem/WorldFiles.java
+++ b/src/main/java/org/spout/engine/filesystem/WorldFiles.java
@@ -67,6 +67,7 @@ import org.spout.engine.SpoutEngine;
 import org.spout.engine.entity.SpoutEntity;
 import org.spout.engine.world.FilteredChunk;
 import org.spout.engine.world.SpoutChunk;
+import org.spout.engine.world.SpoutChunk.PopulationState;
 import org.spout.engine.world.SpoutRegion;
 import org.spout.engine.world.SpoutWorld;
 import org.spout.engine.world.dynamic.DynamicBlockUpdate;
@@ -272,7 +273,7 @@ public class WorldFiles {
 		chunkTags.put(new IntTag("x", c.getX()));
 		chunkTags.put(new IntTag("y", c.getY()));
 		chunkTags.put(new IntTag("z", c.getZ()));
-		chunkTags.put(new ByteTag("populated", c.isPopulated()));
+		chunkTags.put(new ByteTag("populationState", c.getPopulationState().getId()));
 		chunkTags.put(new ShortArrayTag("blocks", blocks));
 		chunkTags.put(new ShortArrayTag("data", data));
 		chunkTags.put(new ByteArrayTag("skyLight", skyLight));
@@ -323,7 +324,7 @@ public class WorldFiles {
 			int cy = r.getChunkY() + y;
 			int cz = r.getChunkZ() + z;
 
-			boolean populated = SafeCast.toGeneric(map.get("populated"), new ByteTag("", false), ByteTag.class).getBooleanValue();
+			byte populationState = SafeCast.toGeneric(map.get("populationState"), new ByteTag("", PopulationState.POPULATED.getId()), ByteTag.class).getValue();
 			short[] blocks = SafeCast.toShortArray(NBTMapper.toTagValue(map.get("blocks")), null);
 			short[] data = SafeCast.toShortArray(NBTMapper.toTagValue(map.get("data")), null);
 			byte[] skyLight = SafeCast.toByteArray(NBTMapper.toTagValue(map.get("skyLight")), null);
@@ -360,7 +361,7 @@ public class WorldFiles {
 			DatatableMap extraDataMap = new GenericDatatableMap();
 			extraDataMap.decompress(extraData);
 
-			chunk = new FilteredChunk(r.getWorld(), r, cx, cy, cz, populated, blocks, data, skyLight, blockLight, manager, extraDataMap);
+			chunk = new FilteredChunk(r.getWorld(), r, cx, cy, cz, PopulationState.byID(populationState), blocks, data, skyLight, blockLight, manager, extraDataMap);
 
 			CompoundMap entityMap = SafeCast.toGeneric(NBTMapper.toTagValue(map.get("entities")), null, CompoundMap.class);
 			loadEntities(r, entityMap, dataForRegion.loadedEntities);

--- a/src/main/java/org/spout/engine/mesh/BaseMesh.java
+++ b/src/main/java/org/spout/engine/mesh/BaseMesh.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 
 import org.spout.api.model.Mesh;
 import org.spout.api.model.ModelFace;
-import org.spout.api.model.PositionNormalTexture;
+import org.spout.api.model.Vertex;
 import org.spout.api.render.RenderEffect;
 import org.spout.api.render.Renderer;
 import org.spout.api.resource.Resource;
@@ -80,7 +80,7 @@ public class BaseMesh extends Resource implements Mesh, Iterable<ModelFace> {
 
 	protected void batch(Renderer batcher) {
 		for (ModelFace face : faces) {
-			for(PositionNormalTexture vert : face){
+			for(Vertex vert : face){
 				//batcher.addTexCoord(vert.uv);
 				//batcher.addNormal(vert.normal);
 				batcher.addVertex(vert.position);

--- a/src/main/java/org/spout/engine/renderer/VertexBufferBatcher.java
+++ b/src/main/java/org/spout/engine/renderer/VertexBufferBatcher.java
@@ -64,21 +64,21 @@ public class VertexBufferBatcher extends BatchVertexRenderer {
 		FloatBuffer verts = BufferUtils.createFloatBuffer(size);
 		verts.put(vertexBuffer.toArray());
 		int offset = 0;
-		buffer.enableAttribute(VERTEX_LOCATION, offset);
+		buffer.enableAttribute("vPosition", VERTEX_LOCATION, offset);
 		if(useColors){
 			verts.put(colorBuffer.toArray());
 			offset += this.numVerticies * SIZE_FLOAT * 4;
-			buffer.enableAttribute(COLOR_LOCATION, offset);
+			buffer.enableAttribute("vColor", COLOR_LOCATION, offset);
 		}
 		if(useNormals){
 			verts.put(normalBuffer.toArray());
 			offset += this.numVerticies * SIZE_FLOAT * 4;
-			buffer.enableAttribute(NORMAL_LOCATION, offset);
+			buffer.enableAttribute("vNormal", NORMAL_LOCATION, offset);
 		}
 		if(useTextures){
 			verts.put(uvBuffer.toArray());
 			offset += this.numVerticies * SIZE_FLOAT * 2;
-			buffer.enableAttribute(TEXCOORD0_LOCATION, offset);
+			buffer.enableAttribute("vTexcoord", TEXCOORD0_LOCATION, offset);
 		}
 		
 		verts.flip();

--- a/src/main/java/org/spout/engine/renderer/vertexbuffer/FakeVertexBuffer.java
+++ b/src/main/java/org/spout/engine/renderer/vertexbuffer/FakeVertexBuffer.java
@@ -39,7 +39,7 @@ public class FakeVertexBuffer extends VertexBuffer {
 	}
 
 	@Override
-	public void enableAttribute(int location, int offset) {
+	public void enableAttribute(String name, int location, int offset) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/org/spout/engine/renderer/vertexbuffer/VertexBuffer.java
+++ b/src/main/java/org/spout/engine/renderer/vertexbuffer/VertexBuffer.java
@@ -49,7 +49,7 @@ public abstract class VertexBuffer {
 	 * @param location
 	 * @param offset
 	 */
-	public abstract void enableAttribute(int location, int offset);
+	public abstract void enableAttribute(String name, int location, int offset);
 	/**
 	 * Binds the buffer to be drawn
 	 * 

--- a/src/main/java/org/spout/engine/resources/loader/MeshLoader.java
+++ b/src/main/java/org/spout/engine/resources/loader/MeshLoader.java
@@ -120,7 +120,7 @@ public class MeshLoader extends BasicResourceLoader<BaseMesh> {
 	
 	@Override
 	public String getFallbackResourceName() {
-		return "mesh://Spout/resources/fallback.obj";
+		return "mesh://Spoutresources/fallbacks/fallback.obj";
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/resources/loader/MeshLoader.java
+++ b/src/main/java/org/spout/engine/resources/loader/MeshLoader.java
@@ -33,7 +33,7 @@ import java.util.Scanner;
 import org.spout.api.math.Vector2;
 import org.spout.api.math.Vector3;
 import org.spout.api.model.ModelFace;
-import org.spout.api.model.PositionNormalTexture;
+import org.spout.api.model.Vertex;
 import org.spout.api.resource.BasicResourceLoader;
 import org.spout.engine.mesh.BaseMesh;
 
@@ -68,24 +68,24 @@ public class MeshLoader extends BasicResourceLoader<BaseMesh> {
 				String[] sp = s.split(" ");
 				
 				if(sp[1].contains("//")){
-					ArrayList<PositionNormalTexture> ar = new ArrayList<PositionNormalTexture>();
+					ArrayList<Vertex> ar = new ArrayList<Vertex>();
 					for(int i = 1; i <= 3; i++){
 						String[] sn = sp[i].split("//");
 						int pos = Integer.parseInt(sn[0]);
 						int norm = Integer.parseInt(sn[1]);
-						ar.add(new PositionNormalTexture(verticies.get(pos - 1), normals.get(norm -1)));
+						ar.add(new Vertex(verticies.get(pos - 1), normals.get(norm -1)));
 											
 					}
 					faces.add(new ModelFace(ar.get(0), ar.get(1), ar.get(2)));
 					ar.clear();
 					
 				} else if(sp[1].contains("/")){
-					ArrayList<PositionNormalTexture> ar = new ArrayList<PositionNormalTexture>();
+					ArrayList<Vertex> ar = new ArrayList<Vertex>();
 					for(int i = 1; i <= 3; i++){
 						String[] sn = sp[i].split("/");
 						int pos = Integer.parseInt(sn[0]);
 						int uv = Integer.parseInt(sn[1]);
-						ar.add(new PositionNormalTexture(verticies.get(pos - 1), uvs.get(uv -1)));
+						ar.add(new Vertex(verticies.get(pos - 1), uvs.get(uv -1)));
 											
 					}
 					faces.add(new ModelFace(ar.get(0), ar.get(1), ar.get(2)));
@@ -97,9 +97,9 @@ public class MeshLoader extends BasicResourceLoader<BaseMesh> {
 					int face2 = Integer.parseInt(sp[2]) - 1;
 					int face3 = Integer.parseInt(sp[3]) - 1;
 					
-					PositionNormalTexture p = new PositionNormalTexture(verticies.get(face1));
-					PositionNormalTexture p2 = new PositionNormalTexture(verticies.get(face2));
-					PositionNormalTexture p3 = new PositionNormalTexture(verticies.get(face3));
+					Vertex p = new Vertex(verticies.get(face1));
+					Vertex p2 = new Vertex(verticies.get(face2));
+					Vertex p3 = new Vertex(verticies.get(face3));
 					
 					faces.add(new ModelFace(p, p2, p3));
 					

--- a/src/main/java/org/spout/engine/resources/loader/MeshLoader.java
+++ b/src/main/java/org/spout/engine/resources/loader/MeshLoader.java
@@ -120,7 +120,7 @@ public class MeshLoader extends BasicResourceLoader<BaseMesh> {
 	
 	@Override
 	public String getFallbackResourceName() {
-		return "mesh://Spoutresources/fallbacks/fallback.obj";
+		return "mesh://Spout/resources/fallbacks/fallback.obj";
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/resources/loader/RenderMaterialLoader.java
+++ b/src/main/java/org/spout/engine/resources/loader/RenderMaterialLoader.java
@@ -53,7 +53,7 @@ import org.spout.engine.resources.ClientRenderMaterial;
 public class RenderMaterialLoader extends BasicResourceLoader<ClientRenderMaterial> {
 	@Override
 	public String getFallbackResourceName() {
-		return "material://Spout/resources/generic.smt";
+		return "material://Spout/resources/fallbacks/generic.smt";
 	}
 
 	private static final TypeChecker<Map<? extends String, ?>> checkerMapStringObject = TypeChecker.tMap(String.class, Object.class);

--- a/src/main/java/org/spout/engine/resources/loader/ShaderLoader.java
+++ b/src/main/java/org/spout/engine/resources/loader/ShaderLoader.java
@@ -96,7 +96,7 @@ public class ShaderLoader extends BasicResourceLoader<ClientShader> {
 
 	@Override
 	public String getFallbackResourceName() {
-		return "shader://Spout/resources/fallback.ssf";
+		return "shader://Spout/resources/fallbacks/fallback.ssf";
 	}
 	
 }

--- a/src/main/java/org/spout/engine/resources/loader/TextureLoader.java
+++ b/src/main/java/org/spout/engine/resources/loader/TextureLoader.java
@@ -59,7 +59,7 @@ public class TextureLoader extends BasicResourceLoader<Texture> {
 
 	@Override
 	public String getFallbackResourceName() {
-		return "texture://Spout/resources/fallback.png";
+		return "texture://Spout/resources/fallbacks/fallback.png";
 	}
 	
 	

--- a/src/main/java/org/spout/engine/util/TicklockMonitor.java
+++ b/src/main/java/org/spout/engine/util/TicklockMonitor.java
@@ -60,7 +60,7 @@ public class TicklockMonitor extends Thread {
 				AsyncExecutorUtils.dumpAllStacks();
 				lastUpTime = upTime;
 			} else {
-				Spout.getLogger().info("Current tick time: " + tickTime);
+				//Spout.getLogger().info("Current tick time: " + tickTime);
 			}
 		}
 	}

--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -232,7 +232,7 @@ public class FilteredChunk extends SpoutChunk{
 	
 	@Override
 	public void syncSave() {
-		if (this.chunkModified.get()) {
+		if (this.chunkModified.compareAndSet(true, false)) {
 			super.syncSave();
 		} else {
 			//System.out.println("Cancelling save of " + toString() + " no modifications");

--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -56,11 +56,11 @@ public class FilteredChunk extends SpoutChunk{
 	}
 
 	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 	}
 
-	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
-		super(world, region, x, y, z, populated, blocks, data, skyLight, blockLight, manager, extraData);
+	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+		super(world, region, x, y, z, popState, blocks, data, skyLight, blockLight, manager, extraData);
 
 		uniform = new AtomicBoolean(true);
 		short id = blocks[0];

--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -62,12 +62,12 @@ public class FilteredChunk extends SpoutChunk{
 	}
 
 	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 		chunkModified.set(true);
 	}
 
-	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
-		super(world, region, x, y, z, populated, blocks, data, skyLight, blockLight, manager, extraData);
+	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+		super(world, region, x, y, z, popState, blocks, data, skyLight, blockLight, manager, extraData);
 
 		uniform = new AtomicBoolean(true);
 		short id = blocks[0];

--- a/src/main/java/org/spout/engine/world/RegionSource.java
+++ b/src/main/java/org/spout/engine/world/RegionSource.java
@@ -47,7 +47,7 @@ import org.spout.engine.util.thread.snapshotable.SnapshotManager;
 
 public class RegionSource implements Iterable<Region> {
 	private final static AtomicInteger regionsLoaded = new AtomicInteger(0);
-	private final static AtomicInteger warnThreshold = new AtomicInteger(2);
+	private final static AtomicInteger warnThreshold = new AtomicInteger(Integer.MAX_VALUE);
 	/**
 	 * A map of loaded regions, mapped to their x and z values.
 	 */

--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -28,6 +28,7 @@ package org.spout.engine.world;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -52,6 +53,8 @@ import org.spout.api.generator.Populator;
 import org.spout.api.generator.WorldGeneratorUtils;
 import org.spout.api.generator.biome.Biome;
 import org.spout.api.generator.biome.BiomeManager;
+import org.spout.api.generator.biome.BiomePopulator;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.ChunkSnapshot;
@@ -101,9 +104,8 @@ public class SpoutChunk extends Chunk {
 	private static final int mainThreadStages = TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	private static final int allowedStages = TickStage.STAGE1 | TickStage.STAGE2P | TickStage.TICKSTART;
 	private static final int updateStages =
-			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS |
-			TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
-
+			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS
+			| TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	/**
 	 * Time in ms between chunk reaper unload checks
 	 */
@@ -124,7 +126,7 @@ public class SpoutChunk extends Chunk {
 	/**
 	 * Holds if the chunk is populated
 	 */
-	private AtomicBoolean populated;
+	private final AtomicReference<PopulationState> populationState;
 	/**
 	 * Snapshot Manager
 	 */
@@ -147,14 +149,12 @@ public class SpoutChunk extends Chunk {
 	 */
 	protected byte[] skyLight;
 	protected byte[] blockLight;
-
 	/**
 	 * The mask that should be applied to the x, y and z coords
 	 */
 	protected final SpoutColumn column;
 	protected final AtomicBoolean columnRegistered = new AtomicBoolean(true);
 	protected final AtomicLong lastUnloadCheck = new AtomicLong();
-
 	/**
 	 * True if this chunk is initializing lighting, False if not
 	 */
@@ -165,9 +165,8 @@ public class SpoutChunk extends Chunk {
 	protected final AtomicBoolean lightDirty = new AtomicBoolean(false);
 	/**
 	 * If -1, there are no changes. If higher, there are changes and the number
-	 * denotes how many ticks these have been there.<br>
-	 * Every time a change is committed the value is set to 0. The region will
-	 * increment it as well.
+	 * denotes how many ticks these have been there.<br> Every time a change is
+	 * committed the value is set to 0. The region will increment it as well.
 	 */
 	protected final AtomicInteger lightingCounter = new AtomicInteger(-1);
 	/**
@@ -183,23 +182,19 @@ public class SpoutChunk extends Chunk {
 	 */
 	private final AtomicBoolean renderDirtyFlag = new AtomicBoolean(true);
 	private final AtomicBoolean renderSnapshotInProgress = new AtomicBoolean(false);
-
 	/**
 	 * Data map and Datatable associated with it
 	 */
 	protected final DatatableMap datatableMap;
 	protected final DataMap dataMap;
-
 	/**
 	 * Manages the biomes for this chunk
 	 */
 	private final BiomeManager biomes;
-
 	/**
 	 * Shift cache array for shifting fields
 	 */
 	protected final static int[] shiftCache = new int[65536];
-
 	/**
 	 * The thread associated with the region
 	 */
@@ -217,14 +212,14 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 	}
 
-	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
 		super(world, x * BLOCKS.SIZE, y * BLOCKS.SIZE, z * BLOCKS.SIZE);
 		parentRegion = region;
 		blockStore = new AtomicBlockStoreImpl(BLOCKS.BITS, 10, blocks, data);
-		this.populated = new AtomicBoolean(populated);
+		this.populationState = new AtomicReference<PopulationState>(popState);
 
 		if (skyLight == null) {
 			this.skyLight = new byte[BLOCKS.HALF_VOLUME];
@@ -253,7 +248,7 @@ public class SpoutChunk extends Chunk {
 		// loaded chunk
 		this.biomes = manager;
 		this.regionThread = region.getExceutionThread();
-		this.mainThread = ((SpoutScheduler)Spout.getScheduler()).getMainThread();
+		this.mainThread = ((SpoutScheduler) Spout.getScheduler()).getMainThread();
 
 		((SpoutEngine) world.getEngine()).getLeakThread().monitor(this);
 		activeChunks.incrementAndGet();
@@ -750,7 +745,7 @@ public class SpoutChunk extends Chunk {
 	public boolean copySnapshotRun() {
 		// NOTE : This is only called for chunks with contain entities.
 		snapshotManager.copyAllSnapshots();
-		return entities.get().size() == 0;
+		return entities.get().isEmpty();
 	}
 
 	// Saves the chunk data - this occurs directly after a snapshot update
@@ -836,7 +831,7 @@ public class SpoutChunk extends Chunk {
 		int distance = (int) ((SpoutEntity) entity).getChunkLive().getBase().getDistance(getBase());
 		Integer oldDistance = observers.put(entity, distance);
 		if (oldDistance != null) {
-			// The player was already observing the chunk from distance oldDistance
+			// The player was already observing the chunk from distance oldDistance 
 			return false;
 		}
 
@@ -861,13 +856,17 @@ public class SpoutChunk extends Chunk {
 			return false;
 		}
 
-		if (observers.isEmptyLive()) {
+		if (!isObserved()) {
 			parentRegion.unloadQueue.add(this);
 			if (observed.compareAndSet(true, false)) {
 				observedChunks.decrementAndGet();
 			}
 		}
 		return true;
+	}
+
+	public boolean isObserved() {
+		return !observers.isEmptyLive();
 	}
 
 	public Set<Entity> getObserversLive() {
@@ -907,8 +906,8 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public boolean canSend() {
-		boolean canSend = this.isPopulated() && !this.isCalculatingLighting();
-		if (!canSend && !isPopulated() && this.observers.get().size() > 0 && this.observers.getLive().size() > 0) {
+		boolean canSend = isPopulated() && !this.isCalculatingLighting();
+		if (!canSend && !isPopulated() && isObserved()) {
 			parentRegion.queueChunkForPopulation(this);
 		}
 		return canSend;
@@ -994,7 +993,6 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public static enum SaveState {
-
 		UNLOAD_SAVE, UNLOAD, SAVE, NONE, UNLOADED;
 
 		public boolean isSave() {
@@ -1003,6 +1001,42 @@ public class SpoutChunk extends Chunk {
 
 		public boolean isUnload() {
 			return this == UNLOAD_SAVE || this == UNLOAD;
+		}
+	}
+
+	public static enum PopulationState {
+		UNTOUCHED((byte) 0),
+		CLEAR_POPULATED((byte) 1),
+		POPULATED((byte) 2);
+		private final byte id;
+		private static final PopulationState[] BY_ID;
+
+		static {
+			PopulationState[] values = PopulationState.values();
+			BY_ID = new PopulationState[values.length];
+			int index = 0;
+			for (PopulationState value : values) {
+				BY_ID[index++] = value;
+			}
+		}
+
+		private PopulationState(byte id) {
+			this.id = id;
+		}
+
+		public byte getId() {
+			return id;
+		}
+
+		public boolean incomplete() {
+			return this == UNTOUCHED || this == CLEAR_POPULATED;
+		}
+
+		public static PopulationState byID(byte id) {
+			if (id < 0 || id >= BY_ID.length) {
+				return null;
+			}
+			return BY_ID[id];
 		}
 	}
 
@@ -1018,17 +1052,62 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public void populate(boolean force) {
-		if (this.observers.get().size() == 0 || this.observers.getLive().size() == 0) {
+		if (!isObserved() && !force) {
 			return;
 		}
 
-		if (this.populated.getAndSet(true) && !force) {
+		if (!populationState.get().incomplete() && !force) {
 			return;
 		}
 
-		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42));
+		final List<Populator> clearPopulators = new ArrayList<Populator>();
+		final List<Populator> populators = new ArrayList<Populator>();
+		for (Populator pop : getWorld().getGenerator().getPopulators()) {
+			if (pop.needsClearance()) {
+				clearPopulators.add(pop);
+			} else {
+				populators.add(pop);
+			}
+		}
 
-		for (Populator populator : getWorld().getGenerator().getPopulators()) {
+		final int x = getX();
+		final int y = getY();
+		final int z = getZ();
+
+		if (!clearPopulators.isEmpty()) {
+			final SpoutChunk[] toPopulate = new SpoutChunk[9];
+			int index = 0;
+			for (byte xx = -1; xx <= 1; xx++) {
+				for (byte zz = -1; zz <= 1; zz++) {
+					final SpoutChunk chunk = getWorld().getChunk(x + xx, y, z + zz, LoadOption.LOAD_GEN);
+					if (chunk.getPopulationState() == PopulationState.UNTOUCHED) {
+						toPopulate[index++] = chunk;
+					}
+				}
+			}
+			for (Populator populator : clearPopulators) {
+				try {
+					for (index = 0; index < toPopulate.length; index++) {
+						final SpoutChunk chunk = toPopulate[index];
+						if (chunk != null) {
+							chunk.populate(populator);
+						}
+					}
+				} catch (Exception e) {
+					Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+					e.printStackTrace();
+				}
+			}
+			for (index = 0; index < toPopulate.length; index++) {
+				final SpoutChunk chunk = toPopulate[index];
+				if (chunk != null) {
+					chunk.setPopulationState(PopulationState.CLEAR_POPULATED);
+				}
+			}
+		}
+
+		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), x, y, z, 42));
+		for (Populator populator : populators) {
 			try {
 				populator.populate(this, random);
 			} catch (Exception e) {
@@ -1037,15 +1116,33 @@ public class SpoutChunk extends Chunk {
 			}
 		}
 
+		populationState.set(PopulationState.POPULATED);
 		if (SpoutConfiguration.LIGHTING_ENABLED.getBoolean()) {
 			this.initLighting();
 		}
 		parentRegion.onChunkPopulated(this);
 	}
 
+	public void populate(Populator populator) {
+		try {
+			populator.populate(this, new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42)));
+		} catch (Exception e) {
+			Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+			e.printStackTrace();
+		}
+	}
+
 	@Override
 	public boolean isPopulated() {
-		return populated.get();
+		return populationState.get() == PopulationState.POPULATED;
+	}
+
+	public PopulationState getPopulationState() {
+		return populationState.get();
+	}
+
+	public void setPopulationState(PopulationState state) {
+		populationState.set(state);
 	}
 
 	@Override
@@ -1290,7 +1387,7 @@ public class SpoutChunk extends Chunk {
 		}
 
 		lastUnloadCheck.set(worldAge);
-		return this.observers.getLive().size() <= 0 && this.observers.get().size() <= 0;
+		return !isObserved();
 	}
 
 	public void notifyColumn() {

--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -28,6 +28,7 @@ package org.spout.engine.world;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -52,6 +53,8 @@ import org.spout.api.generator.Populator;
 import org.spout.api.generator.WorldGeneratorUtils;
 import org.spout.api.generator.biome.Biome;
 import org.spout.api.generator.biome.BiomeManager;
+import org.spout.api.generator.biome.BiomePopulator;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.ChunkSnapshot;
@@ -95,9 +98,8 @@ public class SpoutChunk extends Chunk {
 	private static final int mainThreadStages = TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	private static final int allowedStages = TickStage.STAGE1 | TickStage.STAGE2P | TickStage.TICKSTART;
 	private static final int updateStages =
-			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS |
-			TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
-
+			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS
+			| TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	/**
 	 * Time in ms between chunk reaper unload checks
 	 */
@@ -118,7 +120,7 @@ public class SpoutChunk extends Chunk {
 	/**
 	 * Holds if the chunk is populated
 	 */
-	private AtomicBoolean populated;
+	private final AtomicReference<PopulationState> populationState;
 	/**
 	 * Snapshot Manager
 	 */
@@ -141,14 +143,12 @@ public class SpoutChunk extends Chunk {
 	 */
 	protected byte[] skyLight;
 	protected byte[] blockLight;
-
 	/**
 	 * The mask that should be applied to the x, y and z coords
 	 */
 	protected final SpoutColumn column;
 	protected final AtomicBoolean columnRegistered = new AtomicBoolean(true);
 	protected final AtomicLong lastUnloadCheck = new AtomicLong();
-
 	/**
 	 * True if this chunk is initializing lighting, False if not
 	 */
@@ -159,9 +159,8 @@ public class SpoutChunk extends Chunk {
 	protected final AtomicBoolean lightDirty = new AtomicBoolean(false);
 	/**
 	 * If -1, there are no changes. If higher, there are changes and the number
-	 * denotes how many ticks these have been there.<br>
-	 * Every time a change is committed the value is set to 0. The region will
-	 * increment it as well.
+	 * denotes how many ticks these have been there.<br> Every time a change is
+	 * committed the value is set to 0. The region will increment it as well.
 	 */
 	protected final AtomicInteger lightingCounter = new AtomicInteger(-1);
 	/**
@@ -177,23 +176,19 @@ public class SpoutChunk extends Chunk {
 	 */
 	private final AtomicBoolean renderDirtyFlag = new AtomicBoolean(true);
 	private final AtomicBoolean renderSnapshotInProgress = new AtomicBoolean(false);
-
 	/**
 	 * Data map and Datatable associated with it
 	 */
 	protected final DatatableMap datatableMap;
 	protected final DataMap dataMap;
-
 	/**
 	 * Manages the biomes for this chunk
 	 */
 	private final BiomeManager biomes;
-
 	/**
 	 * Shift cache array for shifting fields
 	 */
 	protected final static int[] shiftCache = new int[65536];
-
 	/**
 	 * The thread associated with the region
 	 */
@@ -211,14 +206,14 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 	}
 
-	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
 		super(world, x * BLOCKS.SIZE, y * BLOCKS.SIZE, z * BLOCKS.SIZE);
 		parentRegion = region;
 		blockStore = new AtomicBlockStoreImpl(BLOCKS.BITS, 10, blocks, data);
-		this.populated = new AtomicBoolean(populated);
+		this.populationState = new AtomicReference<PopulationState>(popState);
 
 		if (skyLight == null) {
 			this.skyLight = new byte[BLOCKS.HALF_VOLUME];
@@ -247,7 +242,7 @@ public class SpoutChunk extends Chunk {
 		// loaded chunk
 		this.biomes = manager;
 		this.regionThread = region.getExceutionThread();
-		this.mainThread = ((SpoutScheduler)Spout.getScheduler()).getMainThread();
+		this.mainThread = ((SpoutScheduler) Spout.getScheduler()).getMainThread();
 
 		((SpoutEngine) world.getEngine()).getLeakThread().monitor(this);
 	}
@@ -731,7 +726,7 @@ public class SpoutChunk extends Chunk {
 	public boolean copySnapshotRun() {
 		// NOTE : This is only called for chunks with contain entities.
 		snapshotManager.copyAllSnapshots();
-		return entities.get().size() == 0;
+		return entities.get().isEmpty();
 	}
 
 	// Saves the chunk data - this occurs directly after a snapshot update
@@ -793,7 +788,7 @@ public class SpoutChunk extends Chunk {
 		int distance = (int) ((SpoutEntity) entity).getChunkLive().getBase().getDistance(getBase());
 		Integer oldDistance = observers.put(entity, distance);
 		if (oldDistance != null) {
-			// The player was already observing the chunk from distance oldDistance
+			// The player was already observing the chunk from distance oldDistance 
 			return false;
 		}
 
@@ -815,10 +810,14 @@ public class SpoutChunk extends Chunk {
 			return false;
 		}
 
-		if (observers.isEmptyLive()) {
+		if (!isObserved()) {
 			parentRegion.unloadQueue.add(this);
 		}
 		return true;
+	}
+
+	public boolean isObserved() {
+		return !observers.isEmptyLive();
 	}
 
 	public Set<Entity> getObserversLive() {
@@ -858,8 +857,8 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public boolean canSend() {
-		boolean canSend = this.isPopulated() && !this.isCalculatingLighting();
-		if (!canSend && !isPopulated() && this.observers.get().size() > 0 && this.observers.getLive().size() > 0) {
+		boolean canSend = isPopulated() && !this.isCalculatingLighting();
+		if (!canSend && !isPopulated() && isObserved()) {
 			parentRegion.queueChunkForPopulation(this);
 		}
 		return canSend;
@@ -928,7 +927,6 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public static enum SaveState {
-
 		UNLOAD_SAVE, UNLOAD, SAVE, NONE, UNLOADED;
 
 		public boolean isSave() {
@@ -937,6 +935,42 @@ public class SpoutChunk extends Chunk {
 
 		public boolean isUnload() {
 			return this == UNLOAD_SAVE || this == UNLOAD;
+		}
+	}
+
+	public static enum PopulationState {
+		UNTOUCHED((byte) 0),
+		CLEAR_POPULATED((byte) 1),
+		POPULATED((byte) 2);
+		private final byte id;
+		private static final PopulationState[] BY_ID;
+
+		static {
+			PopulationState[] values = PopulationState.values();
+			BY_ID = new PopulationState[values.length];
+			int index = 0;
+			for (PopulationState value : values) {
+				BY_ID[index++] = value;
+			}
+		}
+
+		private PopulationState(byte id) {
+			this.id = id;
+		}
+
+		public byte getId() {
+			return id;
+		}
+
+		public boolean incomplete() {
+			return this == UNTOUCHED || this == CLEAR_POPULATED;
+		}
+
+		public static PopulationState byID(byte id) {
+			if (id < 0 || id >= BY_ID.length) {
+				return null;
+			}
+			return BY_ID[id];
 		}
 	}
 
@@ -952,17 +986,62 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public void populate(boolean force) {
-		if (this.observers.get().size() == 0 || this.observers.getLive().size() == 0) {
+		if (!isObserved() && !force) {
 			return;
 		}
 
-		if (this.populated.getAndSet(true) && !force) {
+		if (!populationState.get().incomplete() && !force) {
 			return;
 		}
 
-		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42));
+		final List<Populator> clearPopulators = new ArrayList<Populator>();
+		final List<Populator> populators = new ArrayList<Populator>();
+		for (Populator pop : getWorld().getGenerator().getPopulators()) {
+			if (pop.needsClearance()) {
+				clearPopulators.add(pop);
+			} else {
+				populators.add(pop);
+			}
+		}
 
-		for (Populator populator : getWorld().getGenerator().getPopulators()) {
+		final int x = getX();
+		final int y = getY();
+		final int z = getZ();
+
+		if (!clearPopulators.isEmpty()) {
+			final SpoutChunk[] toPopulate = new SpoutChunk[9];
+			int index = 0;
+			for (byte xx = -1; xx <= 1; xx++) {
+				for (byte zz = -1; zz <= 1; zz++) {
+					final SpoutChunk chunk = getWorld().getChunk(x + xx, y, z + zz, LoadOption.LOAD_GEN);
+					if (chunk.getPopulationState() == PopulationState.UNTOUCHED) {
+						toPopulate[index++] = chunk;
+					}
+				}
+			}
+			for (Populator populator : clearPopulators) {
+				try {
+					for (index = 0; index < toPopulate.length; index++) {
+						final SpoutChunk chunk = toPopulate[index];
+						if (chunk != null) {
+							chunk.populate(populator);
+						}
+					}
+				} catch (Exception e) {
+					Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+					e.printStackTrace();
+				}
+			}
+			for (index = 0; index < toPopulate.length; index++) {
+				final SpoutChunk chunk = toPopulate[index];
+				if (chunk != null) {
+					chunk.setPopulationState(PopulationState.CLEAR_POPULATED);
+				}
+			}
+		}
+
+		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), x, y, z, 42));
+		for (Populator populator : populators) {
 			try {
 				populator.populate(this, random);
 			} catch (Exception e) {
@@ -971,15 +1050,33 @@ public class SpoutChunk extends Chunk {
 			}
 		}
 
+		populationState.set(PopulationState.POPULATED);
 		if (SpoutConfiguration.LIGHTING_ENABLED.getBoolean()) {
 			this.initLighting();
 		}
 		parentRegion.onChunkPopulated(this);
 	}
 
+	public void populate(Populator populator) {
+		try {
+			populator.populate(this, new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42)));
+		} catch (Exception e) {
+			Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+			e.printStackTrace();
+		}
+	}
+
 	@Override
 	public boolean isPopulated() {
-		return populated.get();
+		return populationState.get() == PopulationState.POPULATED;
+	}
+
+	public PopulationState getPopulationState() {
+		return populationState.get();
+	}
+
+	public void setPopulationState(PopulationState state) {
+		populationState.set(state);
 	}
 
 	@Override
@@ -1224,7 +1321,7 @@ public class SpoutChunk extends Chunk {
 		}
 
 		lastUnloadCheck.set(worldAge);
-		return this.observers.getLive().size() <= 0 && this.observers.get().size() <= 0;
+		return !isObserved();
 	}
 
 	public void notifyColumn() {
@@ -1418,5 +1515,4 @@ public class SpoutChunk extends Chunk {
 	public BiomeManager getBiomeManager() {
 		return biomes;
 	}
-
 }

--- a/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
@@ -46,6 +46,7 @@ import org.spout.api.map.DefaultedMap;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFullState;
 import org.spout.api.util.hashing.NibblePairHashed;
+import org.spout.engine.world.SpoutChunk.PopulationState;
 
 public class SpoutChunkSnapshot extends ChunkSnapshot {
 	/**
@@ -61,7 +62,7 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 	private final byte[] skyLight;
 	private final BiomeManager biomes;
 	private final DefaultedMap<String, Serializable> dataMap;
-	private final boolean populated;
+	private final PopulationState populationState;
 	private boolean renderDirty = false;
 
 	public SpoutChunkSnapshot(SpoutChunk chunk, short[] blockIds, short[] blockData, byte[] blockLight, byte[] skyLight, EntityType type, ExtraData data) {
@@ -112,7 +113,7 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 			this.biomes = null;
 			this.dataMap = null;
 		}
-		this.populated = chunk.isPopulated();
+		this.populationState = chunk.getPopulationState();
 		renderDirty = chunk.isDirty();
 	}
 
@@ -237,7 +238,11 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 
 	@Override
 	public boolean isPopulated() {
-		return populated;
+		return populationState == PopulationState.POPULATED;
+	}
+	
+	public PopulationState getPopulationState() {
+		return populationState;
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/world/SpoutChunkSnapshotFuture.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunkSnapshotFuture.java
@@ -27,24 +27,31 @@
 package org.spout.engine.world;
 
 import org.spout.api.geo.cuboid.ChunkSnapshot;
+import org.spout.api.geo.cuboid.ChunkSnapshot.EntityType;
+import org.spout.api.geo.cuboid.ChunkSnapshot.ExtraData;
+import org.spout.api.geo.cuboid.ChunkSnapshot.SnapshotType;
 import org.spout.api.util.future.SimpleFuture;
 
 public class SpoutChunkSnapshotFuture extends SimpleFuture<ChunkSnapshot> implements Runnable {
 	
 	private final SpoutChunk chunk;
-	private final boolean entities;
+	private final SnapshotType type;
+	private final EntityType entities;
+	private final ExtraData data;
 	private final boolean renderSnapshot;
 	
-	public SpoutChunkSnapshotFuture(SpoutChunk chunk, boolean entities, boolean renderSnapshot) {
+	public SpoutChunkSnapshotFuture(SpoutChunk chunk, SnapshotType type, EntityType entities, ExtraData data, boolean renderSnapshot) {
 		this.chunk = chunk;
+		this.type = type;
 		this.entities = entities;
+		this.data = data;
 		this.renderSnapshot = renderSnapshot;
 	}
 
 	@Override
 	public void run() {
 		try {
-			ChunkSnapshot snapshot = chunk.getSnapshot(entities);
+			ChunkSnapshot snapshot = chunk.getSnapshot(type, entities, data);
 			if (renderSnapshot) {
 				chunk.setRenderClean();
 			}

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -633,7 +633,7 @@ public class SpoutRegion extends Region{
 								x = TByteTripleHashSet.key1(key);
 								y = TByteTripleHashSet.key2(key);
 								z = TByteTripleHashSet.key3(key);
-								SpoutChunk chunk = this.getChunk(x, y, z);
+								SpoutChunk chunk = this.getChunk(x, y, z, LoadOption.NO_LOAD);
 								if (chunk == null || !chunk.isLoaded()) {
 									iter.remove();
 									continue;

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -734,7 +734,10 @@ public class SpoutRegion extends Region{
 			// Compress at most 1 chunk per tick per region
 			boolean chunkCompressed = false;
 	
-			int percentObserved = (100 * SpoutChunk.getObservedChunks()) / (SpoutChunk.getActiveChunks());
+			int percentObserved = 0;
+			if(SpoutChunk.getActiveChunks() != 0) {
+				percentObserved = (100 * SpoutChunk.getObservedChunks()) / (SpoutChunk.getActiveChunks());
+			}
 			
 			int multiplier = percentObserved < 70 ? 20 : (percentObserved >= 90 ? 1 : (90 - percentObserved));
 			int maxReapCount = REAP_PER_TICK * multiplier;

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -64,15 +64,14 @@ import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
+import org.spout.api.geo.cuboid.ChunkSnapshot;
 import org.spout.api.geo.cuboid.Region;
 import org.spout.api.geo.discrete.Point;
 import org.spout.api.io.bytearrayarray.BAAWrapper;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.DynamicUpdateEntry;
 import org.spout.api.material.block.BlockFullState;
-import org.spout.api.material.range.EffectIterator;
 import org.spout.api.material.range.EffectRange;
-import org.spout.api.math.IntVector3;
 import org.spout.api.math.Vector3;
 import org.spout.api.player.Player;
 import org.spout.api.protocol.NetworkSynchronizer;
@@ -450,9 +449,13 @@ public class SpoutRegion extends Region{
 		}
 		markForSaveUnload();
 	}
-
+	
 	@Override
 	public void unload(boolean save) {
+		unload(save, false);
+	}
+
+	public void unload(boolean save, boolean force) {
 		for (int dx = 0; dx < CHUNKS.SIZE; dx++) {
 			for (int dy = 0; dy < CHUNKS.SIZE; dy++) {
 				for (int dz = 0; dz < CHUNKS.SIZE; dz++) {
@@ -462,6 +465,10 @@ public class SpoutRegion extends Region{
 					}
 				}
 			}
+		}
+		if (force) {
+			//Only should occur if the server is shutting down
+			copySnapshotRun();
 		}
 		markForSaveUnload();
 	}
@@ -1044,13 +1051,13 @@ public class SpoutRegion extends Region{
 	}
 
 	/**
-	 * Gets the DataOutputStream corresponding to a given Chunk.<br>
+	 * Gets the DataOutputStream corresponding to a given Chunk Snapshot.<br>
 	 * <br>
 	 * WARNING: This block will be locked until the stream is closed
-	 * @param c the chunk
+	 * @param c the chunk snapshot
 	 * @return the DataOutputStream
 	 */
-	public OutputStream getChunkOutputStream(Chunk c) {
+	public OutputStream getChunkOutputStream(ChunkSnapshot c) {
 		int key = getChunkKey(c.getX(), c.getY(), c.getZ());
 		return chunkStore.getBlockOutputStream(key);
 	}

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -300,10 +300,6 @@ public class SpoutRegion extends Region{
 
 				Spout.getEventManager().callDelayedEvent(new ChunkLoadEvent(newChunk, generated));
 
-				if (!newChunk.isPopulated()) {
-					queueChunkForPopulation(newChunk);
-				}
-
 				return newChunk;
 			}
 

--- a/src/main/java/org/spout/engine/world/SpoutWorld.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorld.java
@@ -869,7 +869,7 @@ public final class SpoutWorld extends AsyncManager implements World {
 		return worldDirectory;
 	}
 
-	public void unload(boolean save) {
+	public void unload(boolean save, boolean force) {
 		this.getLightingManager().abort();
 		if (save) {
 			WorldFiles.saveWorldData(this);
@@ -878,7 +878,7 @@ public final class SpoutWorld extends AsyncManager implements World {
 		final int total = Math.max(1, regions.size());
 		int progress = 0;
 		for (Region r : regions) {
-			r.unload(save);
+			((SpoutRegion)r).unload(save, force);
 			progress++;
 			if (save && progress % 4 == 0) {
 				Spout.getLogger().info("Saving world [" + getName() + "], " + (int)(progress * 100F / total) + "% Complete");

--- a/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
+++ b/src/main/java/org/spout/engine/world/SpoutWorldLighting.java
@@ -68,6 +68,7 @@ public class SpoutWorldLighting extends Thread implements Source {
 
 	public SpoutWorldLighting(SpoutWorld world) {
 		super("Lighting thread for world " + world.getName());
+		setDaemon(true);
 		this.world = world;
 		this.skyLight = new SpoutWorldLightingModel(this, true);
 		this.blockLight = new SpoutWorldLightingModel(this, false);

--- a/src/main/java/org/spout/engine/world/WorldSavingThread.java
+++ b/src/main/java/org/spout/engine/world/WorldSavingThread.java
@@ -79,7 +79,9 @@ public class WorldSavingThread extends Thread{
 		Runnable task;
 		do {
 			task = queue.poll();
-			task.run();
+			if (task != null) {
+				task.run();
+			}
 		} while(task != null);
 	}
 	

--- a/src/main/java/org/spout/engine/world/WorldSavingThread.java
+++ b/src/main/java/org/spout/engine/world/WorldSavingThread.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Spout.
+ *
+ * Copyright (c) 2011-2012, SpoutDev <http://www.spout.org/>
+ * Spout is licensed under the SpoutDev License Version 1.
+ *
+ * Spout is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Spout is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.engine.world;
+
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.spout.api.geo.cuboid.ChunkSnapshot;
+import org.spout.api.geo.cuboid.ChunkSnapshot.EntityType;
+import org.spout.api.geo.cuboid.ChunkSnapshot.ExtraData;
+import org.spout.api.geo.cuboid.ChunkSnapshot.SnapshotType;
+import org.spout.engine.filesystem.WorldFiles;
+import org.spout.engine.world.dynamic.DynamicBlockUpdate;
+
+/**
+ * Dedicated thread to IO write operations for world chunks
+ */
+public class WorldSavingThread extends Thread{
+	private static WorldSavingThread instance = null;
+	private final LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();
+	public WorldSavingThread() {
+		super("World Saving Thread");
+		this.setDaemon(true);
+	}
+	
+	public static void startThread() {
+		if (instance == null) {
+			instance = new WorldSavingThread();
+			instance.start();
+		}
+	}
+	
+	public static void saveChunk(SpoutChunk chunk) {
+		ChunkSaveTask task = instance.new ChunkSaveTask(chunk);
+		instance.queue.add(task);
+	}
+	
+	public static void finish() {
+		instance.interrupt();
+		instance.processRemaining();
+	}
+	
+	@Override
+	public void run() {
+		while(!this.isInterrupted()) {
+			Runnable task;
+			try {
+				task = queue.take();
+				task.run();
+			} catch (InterruptedException ignore) { }
+		}
+	}
+	
+	public void processRemaining() {
+		Runnable task;
+		do {
+			task = queue.poll();
+			task.run();
+		} while(task != null);
+	}
+	
+	private class ChunkSaveTask implements Runnable {
+		SpoutRegion region;
+		ChunkSnapshot snapshot;
+		List<DynamicBlockUpdate> blockUpdates;
+		ChunkSaveTask(SpoutChunk chunk) {
+			this.region = chunk.getRegion();
+			this.snapshot = chunk.getSnapshot(SnapshotType.BOTH, EntityType.ENTITIES, ExtraData.BOTH);
+			this.blockUpdates = chunk.getRegion().getDynamicBlockUpdates(chunk);
+		}
+		
+		@Override
+		public void run() {
+			WorldFiles.saveChunk(region.getWorld(), snapshot, blockUpdates, region.getChunkOutputStream(snapshot));
+		}
+	}
+
+}

--- a/src/main/java/org/spout/engine/world/WorldSavingThread.java
+++ b/src/main/java/org/spout/engine/world/WorldSavingThread.java
@@ -87,11 +87,11 @@ public class WorldSavingThread extends Thread{
 	
 	private class ChunkSaveTask implements Runnable {
 		SpoutRegion region;
-		ChunkSnapshot snapshot;
+		SpoutChunkSnapshot snapshot;
 		List<DynamicBlockUpdate> blockUpdates;
 		ChunkSaveTask(SpoutChunk chunk) {
 			this.region = chunk.getRegion();
-			this.snapshot = chunk.getSnapshot(SnapshotType.BOTH, EntityType.ENTITIES, ExtraData.BOTH);
+			this.snapshot = (SpoutChunkSnapshot) chunk.getSnapshot(SnapshotType.BOTH, EntityType.ENTITIES, ExtraData.BOTH);
 			this.blockUpdates = chunk.getRegion().getDynamicBlockUpdates(chunk);
 		}
 		

--- a/src/main/resources/fallbacks/fallback.330.frag
+++ b/src/main/resources/fallbacks/fallback.330.frag
@@ -2,12 +2,12 @@
 
 in vec4 color;
 in vec2 uvcoord;
-uniform sampler2D tex;
+uniform sampler2D Diffuse;
 
 layout(location=0) out vec4 outputColor;
 									
 void main()
 {
 	//outputColor =  color;
-	outputColor = texture(tex, uvcoord);
+	outputColor = texture(Diffuse, uvcoord);
 } 

--- a/src/main/resources/fallbacks/fallback.ssf
+++ b/src/main/resources/fallbacks/fallback.ssf
@@ -1,7 +1,7 @@
 GL30:
-    Vertex: file://Spout/fallbacks/fallback.330.vert
-    Fragment: file://Spout/fallbacks/fallback.330.frag
+    Vertex: file://Spout/resources/fallbacks/fallback.330.vert
+    Fragment: file://Spout/resources/fallbacks/fallback.330.frag
 GL20:
-    Vertex: file://Spout/fallbacks/fallback.120.vert
-    Fragment: file://Spout/fallbacks/fallback.120.frag
+    Vertex: file://Spout/resources/fallbacks/fallback.120.vert
+    Fragment: file://Spout/resources/fallbacks/fallback.120.frag
     

--- a/src/main/resources/fallbacks/generic.smt
+++ b/src/main/resources/fallbacks/generic.smt
@@ -1,5 +1,5 @@
-Shader: shader://Spout/fallbacks/fallback.ssf
+Shader: shader://Spout/resources/fallbacks/fallback.ssf
 
 MaterialParams:
-    Diffuse: texture://Spout/fallbacks/fallback.png
+    Diffuse: texture://Spout/resources/fallbacks/fallback.png
     

--- a/src/main/resources/resources/shaders/guiShader.330.frag
+++ b/src/main/resources/resources/shaders/guiShader.330.frag
@@ -1,13 +1,13 @@
 #version 330
 
-in vec4 color;
 in vec2 uvcoord;
 uniform sampler2D Diffuse;
+uniform vec4 Color;
 
 
 layout(location=0) out vec4 outputColor;
 
 void main()
 {
-	outputColor = texture(Diffuse, uvcoord) * color;
+	outputColor = texture(Diffuse, uvcoord) * Color;
 } 


### PR DESCRIPTION
This is to prevent conflicts between populators. The Vanilla smooth populator has to populate all chunks adjacent to a chunk that requires population, to prevent conflicts with other populators (which would cause structures like trees and ponds to be smoothed). This sort of conflict can happen with any populator that does heavy terrain modifications.

This PR adds:
- A PopulationState enum, instead of a boolean, to allow for better tracking of the population state of a chunk (since with this system chunks may not always be fully populated).
- New population code, that properly handles populators that need clearance
- An isObserved method, to reduce duplicate code

Population queueing is removed from the chunk generation method, to prevent a leak.

Some formatting too.

Related PRs:
https://github.com/SpoutDev/SpoutAPI/pull/261
https://github.com/VanillaDev/Vanilla/pull/243

Signed-off-by: Aleksi Sapon QcTechs@gmail.com
