### PR TITLE
Fixed infinite loop issue

### DIFF
--- a/src/main/java/org/spout/engine/world/dynamic/DynamicBlockUpdateTree.java
+++ b/src/main/java/org/spout/engine/world/dynamic/DynamicBlockUpdateTree.java
@@ -309,7 +309,6 @@ public class DynamicBlockUpdateTree {
 	private DynamicBlockUpdate add(DynamicBlockUpdate update) {
 		int key = update.getPacked();
 		DynamicBlockUpdate oldRoot = blockToUpdateMap.get(key);
-		
 		DynamicBlockUpdate previous = null;
 		if (oldRoot != null) {
 			DynamicBlockUpdate current = oldRoot;
@@ -321,6 +320,9 @@ public class DynamicBlockUpdateTree {
 					previous = current;
 					oldRoot = blockToUpdateMap.get(key);
 					break;
+				} else {
+					// Obtain next update of this block
+					current = current.getNext();
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

Triggering the same block twice would cause 2 dynamic update entries per block. A while loop was not properly going to the next element.
