### PR TITLE
Added populator clearance

### DIFF
--- a/src/main/java/org/spout/engine/filesystem/WorldFiles.java
+++ b/src/main/java/org/spout/engine/filesystem/WorldFiles.java
@@ -67,6 +67,7 @@ import org.spout.engine.SpoutEngine;
 import org.spout.engine.entity.SpoutEntity;
 import org.spout.engine.world.FilteredChunk;
 import org.spout.engine.world.SpoutChunk;
+import org.spout.engine.world.SpoutChunk.PopulationState;
 import org.spout.engine.world.SpoutRegion;
 import org.spout.engine.world.SpoutWorld;
 import org.spout.engine.world.dynamic.DynamicBlockUpdate;
@@ -272,7 +273,7 @@ public class WorldFiles {
 		chunkTags.put(new IntTag("x", c.getX()));
 		chunkTags.put(new IntTag("y", c.getY()));
 		chunkTags.put(new IntTag("z", c.getZ()));
-		chunkTags.put(new ByteTag("populated", c.isPopulated()));
+		chunkTags.put(new ByteTag("populationState", c.getPopulationState().getId()));
 		chunkTags.put(new ShortArrayTag("blocks", blocks));
 		chunkTags.put(new ShortArrayTag("data", data));
 		chunkTags.put(new ByteArrayTag("skyLight", skyLight));
@@ -323,7 +324,7 @@ public class WorldFiles {
 			int cy = r.getChunkY() + y;
 			int cz = r.getChunkZ() + z;
 
-			boolean populated = SafeCast.toGeneric(map.get("populated"), new ByteTag("", false), ByteTag.class).getBooleanValue();
+			byte populationState = SafeCast.toGeneric(map.get("populationState"), new ByteTag("", PopulationState.POPULATED.getId()), ByteTag.class).getValue();
 			short[] blocks = SafeCast.toShortArray(NBTMapper.toTagValue(map.get("blocks")), null);
 			short[] data = SafeCast.toShortArray(NBTMapper.toTagValue(map.get("data")), null);
 			byte[] skyLight = SafeCast.toByteArray(NBTMapper.toTagValue(map.get("skyLight")), null);
@@ -360,7 +361,7 @@ public class WorldFiles {
 			DatatableMap extraDataMap = new GenericDatatableMap();
 			extraDataMap.decompress(extraData);
 
-			chunk = new FilteredChunk(r.getWorld(), r, cx, cy, cz, populated, blocks, data, skyLight, blockLight, manager, extraDataMap);
+			chunk = new FilteredChunk(r.getWorld(), r, cx, cy, cz, PopulationState.byID(populationState), blocks, data, skyLight, blockLight, manager, extraDataMap);
 
 			CompoundMap entityMap = SafeCast.toGeneric(NBTMapper.toTagValue(map.get("entities")), null, CompoundMap.class);
 			loadEntities(r, entityMap, dataForRegion.loadedEntities);

--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -56,11 +56,11 @@ public class FilteredChunk extends SpoutChunk{
 	}
 
 	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 	}
 
-	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
-		super(world, region, x, y, z, populated, blocks, data, skyLight, blockLight, manager, extraData);
+	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+		super(world, region, x, y, z, popState, blocks, data, skyLight, blockLight, manager, extraData);
 
 		uniform = new AtomicBoolean(true);
 		short id = blocks[0];

--- a/src/main/java/org/spout/engine/world/FilteredChunk.java
+++ b/src/main/java/org/spout/engine/world/FilteredChunk.java
@@ -62,12 +62,12 @@ public class FilteredChunk extends SpoutChunk{
 	}
 
 	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 		chunkModified.set(true);
 	}
 
-	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
-		super(world, region, x, y, z, populated, blocks, data, skyLight, blockLight, manager, extraData);
+	public FilteredChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+		super(world, region, x, y, z, popState, blocks, data, skyLight, blockLight, manager, extraData);
 
 		uniform = new AtomicBoolean(true);
 		short id = blocks[0];

--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -28,6 +28,7 @@ package org.spout.engine.world;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -52,6 +53,8 @@ import org.spout.api.generator.Populator;
 import org.spout.api.generator.WorldGeneratorUtils;
 import org.spout.api.generator.biome.Biome;
 import org.spout.api.generator.biome.BiomeManager;
+import org.spout.api.generator.biome.BiomePopulator;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.ChunkSnapshot;
@@ -101,9 +104,8 @@ public class SpoutChunk extends Chunk {
 	private static final int mainThreadStages = TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	private static final int allowedStages = TickStage.STAGE1 | TickStage.STAGE2P | TickStage.TICKSTART;
 	private static final int updateStages =
-			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS |
-			TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
-
+			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS
+			| TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	/**
 	 * Time in ms between chunk reaper unload checks
 	 */
@@ -124,7 +126,7 @@ public class SpoutChunk extends Chunk {
 	/**
 	 * Holds if the chunk is populated
 	 */
-	private AtomicBoolean populated;
+	private final AtomicReference<PopulationState> populationState;
 	/**
 	 * Snapshot Manager
 	 */
@@ -147,14 +149,12 @@ public class SpoutChunk extends Chunk {
 	 */
 	protected byte[] skyLight;
 	protected byte[] blockLight;
-
 	/**
 	 * The mask that should be applied to the x, y and z coords
 	 */
 	protected final SpoutColumn column;
 	protected final AtomicBoolean columnRegistered = new AtomicBoolean(true);
 	protected final AtomicLong lastUnloadCheck = new AtomicLong();
-
 	/**
 	 * True if this chunk is initializing lighting, False if not
 	 */
@@ -165,9 +165,8 @@ public class SpoutChunk extends Chunk {
 	protected final AtomicBoolean lightDirty = new AtomicBoolean(false);
 	/**
 	 * If -1, there are no changes. If higher, there are changes and the number
-	 * denotes how many ticks these have been there.<br>
-	 * Every time a change is committed the value is set to 0. The region will
-	 * increment it as well.
+	 * denotes how many ticks these have been there.<br> Every time a change is
+	 * committed the value is set to 0. The region will increment it as well.
 	 */
 	protected final AtomicInteger lightingCounter = new AtomicInteger(-1);
 	/**
@@ -183,23 +182,19 @@ public class SpoutChunk extends Chunk {
 	 */
 	private final AtomicBoolean renderDirtyFlag = new AtomicBoolean(true);
 	private final AtomicBoolean renderSnapshotInProgress = new AtomicBoolean(false);
-
 	/**
 	 * Data map and Datatable associated with it
 	 */
 	protected final DatatableMap datatableMap;
 	protected final DataMap dataMap;
-
 	/**
 	 * Manages the biomes for this chunk
 	 */
 	private final BiomeManager biomes;
-
 	/**
 	 * Shift cache array for shifting fields
 	 */
 	protected final static int[] shiftCache = new int[65536];
-
 	/**
 	 * The thread associated with the region
 	 */
@@ -217,14 +212,14 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 	}
 
-	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
 		super(world, x * BLOCKS.SIZE, y * BLOCKS.SIZE, z * BLOCKS.SIZE);
 		parentRegion = region;
 		blockStore = new AtomicBlockStoreImpl(BLOCKS.BITS, 10, blocks, data);
-		this.populated = new AtomicBoolean(populated);
+		this.populationState = new AtomicReference<PopulationState>(popState);
 
 		if (skyLight == null) {
 			this.skyLight = new byte[BLOCKS.HALF_VOLUME];
@@ -253,7 +248,7 @@ public class SpoutChunk extends Chunk {
 		// loaded chunk
 		this.biomes = manager;
 		this.regionThread = region.getExceutionThread();
-		this.mainThread = ((SpoutScheduler)Spout.getScheduler()).getMainThread();
+		this.mainThread = ((SpoutScheduler) Spout.getScheduler()).getMainThread();
 
 		((SpoutEngine) world.getEngine()).getLeakThread().monitor(this);
 		activeChunks.incrementAndGet();
@@ -750,7 +745,7 @@ public class SpoutChunk extends Chunk {
 	public boolean copySnapshotRun() {
 		// NOTE : This is only called for chunks with contain entities.
 		snapshotManager.copyAllSnapshots();
-		return entities.get().size() == 0;
+		return entities.get().isEmpty();
 	}
 
 	// Saves the chunk data - this occurs directly after a snapshot update
@@ -836,7 +831,7 @@ public class SpoutChunk extends Chunk {
 		int distance = (int) ((SpoutEntity) entity).getChunkLive().getBase().getDistance(getBase());
 		Integer oldDistance = observers.put(entity, distance);
 		if (oldDistance != null) {
-			// The player was already observing the chunk from distance oldDistance
+			// The player was already observing the chunk from distance oldDistance 
 			return false;
 		}
 
@@ -861,13 +856,17 @@ public class SpoutChunk extends Chunk {
 			return false;
 		}
 
-		if (observers.isEmptyLive()) {
+		if (!isObserved()) {
 			parentRegion.unloadQueue.add(this);
 			if (observed.compareAndSet(true, false)) {
 				observedChunks.decrementAndGet();
 			}
 		}
 		return true;
+	}
+
+	public boolean isObserved() {
+		return !observers.isEmptyLive();
 	}
 
 	public Set<Entity> getObserversLive() {
@@ -907,8 +906,8 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public boolean canSend() {
-		boolean canSend = this.isPopulated() && !this.isCalculatingLighting();
-		if (!canSend && !isPopulated() && this.observers.get().size() > 0 && this.observers.getLive().size() > 0) {
+		boolean canSend = isPopulated() && !this.isCalculatingLighting();
+		if (!canSend && !isPopulated() && isObserved()) {
 			parentRegion.queueChunkForPopulation(this);
 		}
 		return canSend;
@@ -994,7 +993,6 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public static enum SaveState {
-
 		UNLOAD_SAVE, UNLOAD, SAVE, NONE, UNLOADED;
 
 		public boolean isSave() {
@@ -1003,6 +1001,42 @@ public class SpoutChunk extends Chunk {
 
 		public boolean isUnload() {
 			return this == UNLOAD_SAVE || this == UNLOAD;
+		}
+	}
+
+	public static enum PopulationState {
+		UNTOUCHED((byte) 0),
+		CLEAR_POPULATED((byte) 1),
+		POPULATED((byte) 2);
+		private final byte id;
+		private static final PopulationState[] BY_ID;
+
+		static {
+			PopulationState[] values = PopulationState.values();
+			BY_ID = new PopulationState[values.length];
+			int index = 0;
+			for (PopulationState value : values) {
+				BY_ID[index++] = value;
+			}
+		}
+
+		private PopulationState(byte id) {
+			this.id = id;
+		}
+
+		public byte getId() {
+			return id;
+		}
+
+		public boolean incomplete() {
+			return this == UNTOUCHED || this == CLEAR_POPULATED;
+		}
+
+		public static PopulationState byID(byte id) {
+			if (id < 0 || id >= BY_ID.length) {
+				return null;
+			}
+			return BY_ID[id];
 		}
 	}
 
@@ -1018,17 +1052,62 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public void populate(boolean force) {
-		if (this.observers.get().size() == 0 || this.observers.getLive().size() == 0) {
+		if (!isObserved() && !force) {
 			return;
 		}
 
-		if (this.populated.getAndSet(true) && !force) {
+		if (!populationState.get().incomplete() && !force) {
 			return;
 		}
 
-		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42));
+		final List<Populator> clearPopulators = new ArrayList<Populator>();
+		final List<Populator> populators = new ArrayList<Populator>();
+		for (Populator pop : getWorld().getGenerator().getPopulators()) {
+			if (pop.needsClearance()) {
+				clearPopulators.add(pop);
+			} else {
+				populators.add(pop);
+			}
+		}
 
-		for (Populator populator : getWorld().getGenerator().getPopulators()) {
+		final int x = getX();
+		final int y = getY();
+		final int z = getZ();
+
+		if (!clearPopulators.isEmpty()) {
+			final SpoutChunk[] toPopulate = new SpoutChunk[9];
+			int index = 0;
+			for (byte xx = -1; xx <= 1; xx++) {
+				for (byte zz = -1; zz <= 1; zz++) {
+					final SpoutChunk chunk = getWorld().getChunk(x + xx, y, z + zz, LoadOption.LOAD_GEN);
+					if (chunk.getPopulationState() == PopulationState.UNTOUCHED) {
+						toPopulate[index++] = chunk;
+					}
+				}
+			}
+			for (Populator populator : clearPopulators) {
+				try {
+					for (index = 0; index < toPopulate.length; index++) {
+						final SpoutChunk chunk = toPopulate[index];
+						if (chunk != null) {
+							chunk.populate(populator);
+						}
+					}
+				} catch (Exception e) {
+					Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+					e.printStackTrace();
+				}
+			}
+			for (index = 0; index < toPopulate.length; index++) {
+				final SpoutChunk chunk = toPopulate[index];
+				if (chunk != null) {
+					chunk.setPopulationState(PopulationState.CLEAR_POPULATED);
+				}
+			}
+		}
+
+		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), x, y, z, 42));
+		for (Populator populator : populators) {
 			try {
 				populator.populate(this, random);
 			} catch (Exception e) {
@@ -1037,15 +1116,33 @@ public class SpoutChunk extends Chunk {
 			}
 		}
 
+		populationState.set(PopulationState.POPULATED);
 		if (SpoutConfiguration.LIGHTING_ENABLED.getBoolean()) {
 			this.initLighting();
 		}
 		parentRegion.onChunkPopulated(this);
 	}
 
+	public void populate(Populator populator) {
+		try {
+			populator.populate(this, new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42)));
+		} catch (Exception e) {
+			Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+			e.printStackTrace();
+		}
+	}
+
 	@Override
 	public boolean isPopulated() {
-		return populated.get();
+		return populationState.get() == PopulationState.POPULATED;
+	}
+
+	public PopulationState getPopulationState() {
+		return populationState.get();
+	}
+
+	public void setPopulationState(PopulationState state) {
+		populationState.set(state);
 	}
 
 	@Override
@@ -1290,7 +1387,7 @@ public class SpoutChunk extends Chunk {
 		}
 
 		lastUnloadCheck.set(worldAge);
-		return this.observers.getLive().size() <= 0 && this.observers.get().size() <= 0;
+		return !isObserved();
 	}
 
 	public void notifyColumn() {

--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -28,6 +28,7 @@ package org.spout.engine.world;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -52,6 +53,8 @@ import org.spout.api.generator.Populator;
 import org.spout.api.generator.WorldGeneratorUtils;
 import org.spout.api.generator.biome.Biome;
 import org.spout.api.generator.biome.BiomeManager;
+import org.spout.api.generator.biome.BiomePopulator;
+import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.cuboid.ChunkSnapshot;
@@ -95,9 +98,8 @@ public class SpoutChunk extends Chunk {
 	private static final int mainThreadStages = TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	private static final int allowedStages = TickStage.STAGE1 | TickStage.STAGE2P | TickStage.TICKSTART;
 	private static final int updateStages =
-			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS |
-			TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
-
+			TickStage.PHYSICS | TickStage.DYNAMIC_BLOCKS
+			| TickStage.GLOBAL_PHYSICS | TickStage.GLOBAL_DYNAMIC_BLOCKS;
 	/**
 	 * Time in ms between chunk reaper unload checks
 	 */
@@ -118,7 +120,7 @@ public class SpoutChunk extends Chunk {
 	/**
 	 * Holds if the chunk is populated
 	 */
-	private AtomicBoolean populated;
+	private final AtomicReference<PopulationState> populationState;
 	/**
 	 * Snapshot Manager
 	 */
@@ -141,14 +143,12 @@ public class SpoutChunk extends Chunk {
 	 */
 	protected byte[] skyLight;
 	protected byte[] blockLight;
-
 	/**
 	 * The mask that should be applied to the x, y and z coords
 	 */
 	protected final SpoutColumn column;
 	protected final AtomicBoolean columnRegistered = new AtomicBoolean(true);
 	protected final AtomicLong lastUnloadCheck = new AtomicLong();
-
 	/**
 	 * True if this chunk is initializing lighting, False if not
 	 */
@@ -159,9 +159,8 @@ public class SpoutChunk extends Chunk {
 	protected final AtomicBoolean lightDirty = new AtomicBoolean(false);
 	/**
 	 * If -1, there are no changes. If higher, there are changes and the number
-	 * denotes how many ticks these have been there.<br>
-	 * Every time a change is committed the value is set to 0. The region will
-	 * increment it as well.
+	 * denotes how many ticks these have been there.<br> Every time a change is
+	 * committed the value is set to 0. The region will increment it as well.
 	 */
 	protected final AtomicInteger lightingCounter = new AtomicInteger(-1);
 	/**
@@ -177,23 +176,19 @@ public class SpoutChunk extends Chunk {
 	 */
 	private final AtomicBoolean renderDirtyFlag = new AtomicBoolean(true);
 	private final AtomicBoolean renderSnapshotInProgress = new AtomicBoolean(false);
-
 	/**
 	 * Data map and Datatable associated with it
 	 */
 	protected final DatatableMap datatableMap;
 	protected final DataMap dataMap;
-
 	/**
 	 * Manages the biomes for this chunk
 	 */
 	private final BiomeManager biomes;
-
 	/**
 	 * Shift cache array for shifting fields
 	 */
 	protected final static int[] shiftCache = new int[65536];
-
 	/**
 	 * The thread associated with the region
 	 */
@@ -211,14 +206,14 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, short[] initial, BiomeManager manager, DataMap map) {
-		this(world, region, x, y, z, false, initial, null, null, null, manager, map.getRawMap());
+		this(world, region, x, y, z, PopulationState.UNTOUCHED, initial, null, null, null, manager, map.getRawMap());
 	}
 
-	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, boolean populated, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
+	public SpoutChunk(SpoutWorld world, SpoutRegion region, float x, float y, float z, PopulationState popState, short[] blocks, short[] data, byte[] skyLight, byte[] blockLight, BiomeManager manager, DatatableMap extraData) {
 		super(world, x * BLOCKS.SIZE, y * BLOCKS.SIZE, z * BLOCKS.SIZE);
 		parentRegion = region;
 		blockStore = new AtomicBlockStoreImpl(BLOCKS.BITS, 10, blocks, data);
-		this.populated = new AtomicBoolean(populated);
+		this.populationState = new AtomicReference<PopulationState>(popState);
 
 		if (skyLight == null) {
 			this.skyLight = new byte[BLOCKS.HALF_VOLUME];
@@ -247,7 +242,7 @@ public class SpoutChunk extends Chunk {
 		// loaded chunk
 		this.biomes = manager;
 		this.regionThread = region.getExceutionThread();
-		this.mainThread = ((SpoutScheduler)Spout.getScheduler()).getMainThread();
+		this.mainThread = ((SpoutScheduler) Spout.getScheduler()).getMainThread();
 
 		((SpoutEngine) world.getEngine()).getLeakThread().monitor(this);
 	}
@@ -731,7 +726,7 @@ public class SpoutChunk extends Chunk {
 	public boolean copySnapshotRun() {
 		// NOTE : This is only called for chunks with contain entities.
 		snapshotManager.copyAllSnapshots();
-		return entities.get().size() == 0;
+		return entities.get().isEmpty();
 	}
 
 	// Saves the chunk data - this occurs directly after a snapshot update
@@ -793,7 +788,7 @@ public class SpoutChunk extends Chunk {
 		int distance = (int) ((SpoutEntity) entity).getChunkLive().getBase().getDistance(getBase());
 		Integer oldDistance = observers.put(entity, distance);
 		if (oldDistance != null) {
-			// The player was already observing the chunk from distance oldDistance
+			// The player was already observing the chunk from distance oldDistance 
 			return false;
 		}
 
@@ -815,10 +810,14 @@ public class SpoutChunk extends Chunk {
 			return false;
 		}
 
-		if (observers.isEmptyLive()) {
+		if (!isObserved()) {
 			parentRegion.unloadQueue.add(this);
 		}
 		return true;
+	}
+
+	public boolean isObserved() {
+		return !observers.isEmptyLive();
 	}
 
 	public Set<Entity> getObserversLive() {
@@ -858,8 +857,8 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public boolean canSend() {
-		boolean canSend = this.isPopulated() && !this.isCalculatingLighting();
-		if (!canSend && !isPopulated() && this.observers.get().size() > 0 && this.observers.getLive().size() > 0) {
+		boolean canSend = isPopulated() && !this.isCalculatingLighting();
+		if (!canSend && !isPopulated() && isObserved()) {
 			parentRegion.queueChunkForPopulation(this);
 		}
 		return canSend;
@@ -928,7 +927,6 @@ public class SpoutChunk extends Chunk {
 	}
 
 	public static enum SaveState {
-
 		UNLOAD_SAVE, UNLOAD, SAVE, NONE, UNLOADED;
 
 		public boolean isSave() {
@@ -937,6 +935,42 @@ public class SpoutChunk extends Chunk {
 
 		public boolean isUnload() {
 			return this == UNLOAD_SAVE || this == UNLOAD;
+		}
+	}
+
+	public static enum PopulationState {
+		UNTOUCHED((byte) 0),
+		CLEAR_POPULATED((byte) 1),
+		POPULATED((byte) 2);
+		private final byte id;
+		private static final PopulationState[] BY_ID;
+
+		static {
+			PopulationState[] values = PopulationState.values();
+			BY_ID = new PopulationState[values.length];
+			int index = 0;
+			for (PopulationState value : values) {
+				BY_ID[index++] = value;
+			}
+		}
+
+		private PopulationState(byte id) {
+			this.id = id;
+		}
+
+		public byte getId() {
+			return id;
+		}
+
+		public boolean incomplete() {
+			return this == UNTOUCHED || this == CLEAR_POPULATED;
+		}
+
+		public static PopulationState byID(byte id) {
+			if (id < 0 || id >= BY_ID.length) {
+				return null;
+			}
+			return BY_ID[id];
 		}
 	}
 
@@ -952,17 +986,62 @@ public class SpoutChunk extends Chunk {
 
 	@Override
 	public void populate(boolean force) {
-		if (this.observers.get().size() == 0 || this.observers.getLive().size() == 0) {
+		if (!isObserved() && !force) {
 			return;
 		}
 
-		if (this.populated.getAndSet(true) && !force) {
+		if (!populationState.get().incomplete() && !force) {
 			return;
 		}
 
-		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42));
+		final List<Populator> clearPopulators = new ArrayList<Populator>();
+		final List<Populator> populators = new ArrayList<Populator>();
+		for (Populator pop : getWorld().getGenerator().getPopulators()) {
+			if (pop.needsClearance()) {
+				clearPopulators.add(pop);
+			} else {
+				populators.add(pop);
+			}
+		}
 
-		for (Populator populator : getWorld().getGenerator().getPopulators()) {
+		final int x = getX();
+		final int y = getY();
+		final int z = getZ();
+
+		if (!clearPopulators.isEmpty()) {
+			final SpoutChunk[] toPopulate = new SpoutChunk[9];
+			int index = 0;
+			for (byte xx = -1; xx <= 1; xx++) {
+				for (byte zz = -1; zz <= 1; zz++) {
+					final SpoutChunk chunk = getWorld().getChunk(x + xx, y, z + zz, LoadOption.LOAD_GEN);
+					if (chunk.getPopulationState() == PopulationState.UNTOUCHED) {
+						toPopulate[index++] = chunk;
+					}
+				}
+			}
+			for (Populator populator : clearPopulators) {
+				try {
+					for (index = 0; index < toPopulate.length; index++) {
+						final SpoutChunk chunk = toPopulate[index];
+						if (chunk != null) {
+							chunk.populate(populator);
+						}
+					}
+				} catch (Exception e) {
+					Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+					e.printStackTrace();
+				}
+			}
+			for (index = 0; index < toPopulate.length; index++) {
+				final SpoutChunk chunk = toPopulate[index];
+				if (chunk != null) {
+					chunk.setPopulationState(PopulationState.CLEAR_POPULATED);
+				}
+			}
+		}
+
+		final Random random = new Random(WorldGeneratorUtils.getSeed(getWorld(), x, y, z, 42));
+		for (Populator populator : populators) {
 			try {
 				populator.populate(this, random);
 			} catch (Exception e) {
@@ -971,15 +1050,33 @@ public class SpoutChunk extends Chunk {
 			}
 		}
 
+		populationState.set(PopulationState.POPULATED);
 		if (SpoutConfiguration.LIGHTING_ENABLED.getBoolean()) {
 			this.initLighting();
 		}
 		parentRegion.onChunkPopulated(this);
 	}
 
+	public void populate(Populator populator) {
+		try {
+			populator.populate(this, new Random(WorldGeneratorUtils.getSeed(getWorld(), getX(), getY(), getZ(), 42)));
+		} catch (Exception e) {
+			Spout.getEngine().getLogger().log(Level.SEVERE, "Could not populate Chunk with " + populator.toString());
+			e.printStackTrace();
+		}
+	}
+
 	@Override
 	public boolean isPopulated() {
-		return populated.get();
+		return populationState.get() == PopulationState.POPULATED;
+	}
+
+	public PopulationState getPopulationState() {
+		return populationState.get();
+	}
+
+	public void setPopulationState(PopulationState state) {
+		populationState.set(state);
 	}
 
 	@Override
@@ -1224,7 +1321,7 @@ public class SpoutChunk extends Chunk {
 		}
 
 		lastUnloadCheck.set(worldAge);
-		return this.observers.getLive().size() <= 0 && this.observers.get().size() <= 0;
+		return !isObserved();
 	}
 
 	public void notifyColumn() {
@@ -1418,5 +1515,4 @@ public class SpoutChunk extends Chunk {
 	public BiomeManager getBiomeManager() {
 		return biomes;
 	}
-
 }

--- a/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunkSnapshot.java
@@ -46,6 +46,7 @@ import org.spout.api.map.DefaultedMap;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFullState;
 import org.spout.api.util.hashing.NibblePairHashed;
+import org.spout.engine.world.SpoutChunk.PopulationState;
 
 public class SpoutChunkSnapshot extends ChunkSnapshot {
 	/**
@@ -61,7 +62,7 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 	private final byte[] skyLight;
 	private final BiomeManager biomes;
 	private final DefaultedMap<String, Serializable> dataMap;
-	private final boolean populated;
+	private final PopulationState populationState;
 	private boolean renderDirty = false;
 
 	public SpoutChunkSnapshot(SpoutChunk chunk, short[] blockIds, short[] blockData, byte[] blockLight, byte[] skyLight, EntityType type, ExtraData data) {
@@ -112,7 +113,7 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 			this.biomes = null;
 			this.dataMap = null;
 		}
-		this.populated = chunk.isPopulated();
+		this.populationState = chunk.getPopulationState();
 		renderDirty = chunk.isDirty();
 	}
 
@@ -237,7 +238,11 @@ public class SpoutChunkSnapshot extends ChunkSnapshot {
 
 	@Override
 	public boolean isPopulated() {
-		return populated;
+		return populationState == PopulationState.POPULATED;
+	}
+	
+	public PopulationState getPopulationState() {
+		return populationState;
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -300,10 +300,6 @@ public class SpoutRegion extends Region{
 
 				Spout.getEventManager().callDelayedEvent(new ChunkLoadEvent(newChunk, generated));
 
-				if (!newChunk.isPopulated()) {
-					queueChunkForPopulation(newChunk);
-				}
-
 				return newChunk;
 			}
 

--- a/src/main/java/org/spout/engine/world/WorldSavingThread.java
+++ b/src/main/java/org/spout/engine/world/WorldSavingThread.java
@@ -87,11 +87,11 @@ public class WorldSavingThread extends Thread{
 	
 	private class ChunkSaveTask implements Runnable {
 		SpoutRegion region;
-		ChunkSnapshot snapshot;
+		SpoutChunkSnapshot snapshot;
 		List<DynamicBlockUpdate> blockUpdates;
 		ChunkSaveTask(SpoutChunk chunk) {
 			this.region = chunk.getRegion();
-			this.snapshot = chunk.getSnapshot(SnapshotType.BOTH, EntityType.ENTITIES, ExtraData.BOTH);
+			this.snapshot = (SpoutChunkSnapshot) chunk.getSnapshot(SnapshotType.BOTH, EntityType.ENTITIES, ExtraData.BOTH);
 			this.blockUpdates = chunk.getRegion().getDynamicBlockUpdates(chunk);
 		}
 		


### PR DESCRIPTION
This is to prevent conflicts between populators. The Vanilla smooth populator has to populate all chunks adjacent to a chunk that requires population, to prevent conflicts with other populators (which would cause structures like trees and ponds to be smoothed). This sort of conflict can happen with any populator that does heavy terrain modifications.

This PR adds:
- A PopulationState enum, instead of a boolean, to allow for better tracking of the population state of a chunk (since with this system chunks may not always be fully populated).
- New population code, that properly handles populators that need clearance
- An isObserved method, to reduce duplicate code

Population queueing is removed from the chunk generation method, to prevent a leak.

Some formatting too.

Related PRs:
https://github.com/SpoutDev/SpoutAPI/pull/273
https://github.com/VanillaDev/Vanilla/pull/250

Signed-off-by: Aleksi Sapon QcTechs@gmail.com
