### PR TITLE
Disabled physics when populating

### DIFF
--- a/src/main/java/org/spout/engine/world/SpoutChunk.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunk.java
@@ -1607,6 +1607,7 @@ public class SpoutChunk extends Chunk {
 	}
 
 	private void blockChanged(int x, int y, int z, BlockMaterial newMaterial, short newData, BlockMaterial oldMaterial, short oldData, Source source) {
+		// Handle onPlacement for dynamic materials
 		if (newMaterial instanceof DynamicMaterial) {
 			if (oldMaterial instanceof BlockMaterial) {
 				BlockMaterial oldBlockMaterial = (BlockMaterial) oldMaterial;
@@ -1617,13 +1618,16 @@ public class SpoutChunk extends Chunk {
 				parentRegion.resetDynamicBlock(x, y, z);
 			}
 		}
-		EffectRange physicsRange = newMaterial.getPhysicsRange(newData);
-		queueBlockPhysics(x, y, z, physicsRange, oldMaterial, source);
 
-		if (newMaterial != oldMaterial) {
-			EffectRange destroyRange = oldMaterial.getDestroyRange(oldData);
-			if (destroyRange != physicsRange) {
-				queueBlockPhysics(x, y, z, destroyRange, oldMaterial, source);
+		// Only do physics when not populating
+		if (this.isPopulated()) {
+			EffectRange physicsRange = newMaterial.getPhysicsRange(newData);
+			queueBlockPhysics(x, y, z, physicsRange, oldMaterial, source);
+			if (newMaterial != oldMaterial) {
+				EffectRange destroyRange = oldMaterial.getDestroyRange(oldData);
+				if (destroyRange != physicsRange) {
+					queueBlockPhysics(x, y, z, destroyRange, oldMaterial, source);
+				}
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

Executing physics for every single block is too slow for the world physics to handle. To boost performance, we should rely on the populator doing it's work well without physics being needed at all.

Dynamic material resets are still called, as blocks like cactuses and fire rely on these updates to function. Else they wouldn't grow.
