### PR TITLE
Fix incorrect argument order for glTexImage2D

### DIFF
--- a/src/main/java/org/spout/engine/resources/ClientTexture.java
+++ b/src/main/java/org/spout/engine/resources/ClientTexture.java
@@ -128,7 +128,7 @@ public class ClientTexture extends Texture {
 		//	GL30.glGenerateMipmap(textureID);
 		//}
 
-		GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, height, width, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
+		GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
 
 		//EXTFramebufferObject.glGenerateMipmapEXT(GL11.GL_TEXTURE_2D); //Not sure if this extension is supported on most cards. 
 	}


### PR DESCRIPTION
it's width, height not height, width :p

Signed-off-by: Ian Macalinao ianmacalinao@gmail.com
