### PR TITLE
Fixed an "invalid inferred types for U" error when compiling

### DIFF
--- a/src/main/java/org/spout/engine/filesystem/WorldFiles.java
+++ b/src/main/java/org/spout/engine/filesystem/WorldFiles.java
@@ -365,7 +365,7 @@ public class WorldFiles {
 
 			chunk = new FilteredChunk(r.getWorld(), r, cx, cy, cz, PopulationState.byID(populationState), blocks, data, skyLight, blockLight, manager, extraDataMap);
 
-			CompoundMap entityMap = SafeCast.toGeneric(NBTMapper.toTagValue(map.get("entities")), null, CompoundMap.class);
+			CompoundMap entityMap = SafeCast.toGeneric(NBTMapper.toTagValue(map.get("entities")), (CompoundMap) null, CompoundMap.class);
 			loadEntities(r, entityMap, dataForRegion.loadedEntities);
 
 			List<? extends CompoundTag> updateList = checkerListCompoundTag.checkTag(map.get("dynamic_updates"), null);


### PR DESCRIPTION
When compiling on OpenJDK 1.6.0_24, this error shows up:
`[ERROR] /media/extstorage/docs/repos/spout/Spout/src/main/java/org/spout/engine/filesystem/WorldFiles.java:[368,45] invalid inferred types for U; inferred type does not conform to declared bound(s)`
Casting the null parameter passed in to a CompoundMap seems to fix the problem.
Signed-off-by: Zhuowei Zhang zhuoweizhang@yahoo.com
