### PR TITLE
Made Display close in the render thread as opposed to the thread stop() ...

### DIFF
--- a/src/main/java/org/spout/engine/SpoutClient.java
+++ b/src/main/java/org/spout/engine/SpoutClient.java
@@ -103,6 +103,10 @@ public class SpoutClient extends SpoutEngine implements Client {
 	private VertexBufferBatcher vbBatch;
 	private VertexBufferImpl buffer;
 	private long ticks = 0;
+	
+	// Handle stopping
+	private volatile boolean rendering = true;
+	private String stopMessage = null;
 
 	private BaseMesh cube;
 	private Transform loc;
@@ -215,11 +219,22 @@ public class SpoutClient extends SpoutEngine implements Client {
 	public Input getInput() {
 		return inputManager;
 	}
-
+	
 	@Override
 	public void stop(String message) {
-		Display.destroy();
-		super.stop(message);
+		rendering = false;
+		stopMessage = message;
+	}
+
+	public boolean isRendering() {
+		return rendering;
+	}
+
+	public void stopEngine() {
+		if (rendering) {
+			throw new IllegalStateException("Client is still rendering!");
+		}
+		super.stop(stopMessage);
 	}
 
 	private void buildChunk(SpoutChunkSnapshot snap) {

--- a/src/main/java/org/spout/engine/SpoutEngine.java
+++ b/src/main/java/org/spout/engine/SpoutEngine.java
@@ -116,6 +116,7 @@ import org.spout.engine.scheduler.SpoutParallelTaskManager;
 import org.spout.engine.scheduler.SpoutScheduler;
 import org.spout.engine.util.ConsoleManager;
 import org.spout.engine.util.DeadlockMonitor;
+import org.spout.engine.util.StackTrace;
 import org.spout.engine.util.TicklockMonitor;
 import org.spout.engine.util.thread.AsyncManager;
 import org.spout.engine.util.thread.ThreadAsyncExecutor;

--- a/src/main/java/org/spout/engine/scheduler/SpoutScheduler.java
+++ b/src/main/java/org/spout/engine/scheduler/SpoutScheduler.java
@@ -159,9 +159,9 @@ public final class SpoutScheduler implements Scheduler {
 			int rate = (int) ((1f / TARGET_FPS) * 1000);
 			long lastTick = System.currentTimeMillis();
 			while (!shutdown) {
-				if(Display.isCloseRequested()){
+				if(Display.isCloseRequested() || !c.isRendering()) {
 					c.stop();
-					break;	
+					break;
 				}
 				long startTime = System.currentTimeMillis();
 				long delta = startTime - lastTick;
@@ -178,7 +178,8 @@ public final class SpoutScheduler implements Scheduler {
 				}
 				
 			}
-			
+			Display.destroy();
+			c.stopEngine();
 		}
 	}
 


### PR DESCRIPTION
...is called in. LWJGL does not support a multi-threaded Display.

Signed-off-by: Ian Macalinao ianmacalinao@gmail.com
