### PR TITLE
Fixed entities not dying/synching

### DIFF
--- a/src/main/java/org/spout/engine/entity/RegionEntityManager.java
+++ b/src/main/java/org/spout/engine/entity/RegionEntityManager.java
@@ -28,7 +28,6 @@ package org.spout.engine.entity;
 
 import java.util.Collection;
 
-import org.spout.api.entity.Entity;
 import org.spout.api.entity.Player;
 import org.spout.api.math.MathHelper;
 import org.spout.api.protocol.NetworkSynchronizer;
@@ -96,10 +95,6 @@ public final class RegionEntityManager extends EntityManager {
 				 */
 				Collection<SpoutEntity> snapshots = getRegion().getEntityManager().getAll();
 				/*
-				 * The list of entities that have dirty values.
-				 */
-				Collection<SpoutEntity> dirties = getRegion().getEntityManager().getDirtyAll();
-				/*
 				 * If the live entities' position is in range of the player's view distance + position
 				 */
 				if (MathHelper.distance(player.getPosition(), live.getPosition()) <= playerViewDistance) {
@@ -111,7 +106,7 @@ public final class RegionEntityManager extends EntityManager {
 						/*
 						 * If the entity is in the dirty list and snapshots list then it changed this tick, so sync it!
  						 */
-					} else if (snapshots.contains(live) && dirties.contains(live)) {
+					} else if (snapshots.contains(live)) {
 						/*
 						 * The entity is in a snapshot and a dirty list for updates but swapped controllers. Destroy and spawn it!
 						 */

--- a/src/main/java/org/spout/engine/entity/SpoutEntity.java
+++ b/src/main/java/org/spout/engine/entity/SpoutEntity.java
@@ -66,6 +66,7 @@ public class SpoutEntity implements Entity, Snapshotable {
 	private final AtomicReference<Controller> controllerLive;
 	private final AtomicReference<Chunk> chunkLive;
 	private final AtomicReference<Transform> transformLive;
+	private final AtomicBoolean deadLive = new AtomicBoolean(false);
 	private final AtomicBoolean observerLive = new AtomicBoolean(false);
 	private final AtomicInteger id = new AtomicInteger();
 	private final AtomicInteger viewDistanceLive = new AtomicInteger();
@@ -353,12 +354,13 @@ public class SpoutEntity implements Entity, Snapshotable {
 	@Override
 	public boolean kill() {
 		chunkLive.set(null);
+		deadLive.set(true);
 		return true;
 	}
 
 	@Override
 	public boolean isDead() {
-		return id.get() != NOTSPAWNEDID && (chunkLive.get() == null || entityManagerLive.get() == null);
+		return id.get() != NOTSPAWNEDID && (deadLive.get() || chunkLive.get() == null || entityManagerLive.get() == null);
 	}
 
 	// TODO - needs to be made thread safe


### PR DESCRIPTION
Someone else will have to add an additional onDestroy network synchronizer call to removed killed entities.
