### PR TITLE
Altered region entity manager to use message buffer

### DIFF
--- a/src/main/java/org/spout/engine/protocol/builtin/SpoutEntityProtocol.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/SpoutEntityProtocol.java
@@ -27,6 +27,7 @@
 package org.spout.engine.protocol.builtin;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.spout.api.entity.Entity;
@@ -46,26 +47,27 @@ public class SpoutEntityProtocol implements EntityProtocol {
 		super();
 	}
 
-	public Message[] getSpawnMessage(Entity entity) {
-		return new Message[] {new AddEntityMessage(entity.getId(), entity.getController().getType(), entity.getTransform())};
+	@Override
+	public List<Message> getSpawnMessages(Entity entity) {
+		return Arrays.<Message>asList(new AddEntityMessage(entity.getId(), entity.getController().getType(), entity.getTransform()));
 	}
 
-	public Message[] getDestroyMessage(Entity entity) {
-		return new Message[] {new RemoveEntityMessage(entity.getId())};
+	@Override
+	public List<Message> getDestroyMessages(Entity entity) {
+		return Arrays.<Message>asList(new RemoveEntityMessage(entity.getId()));
 	}
 
-	public Message[] getUpdateMessage(Entity entity) {
-		List<Message> msgs = new ArrayList<Message>(2);
-
+	@Override
+	public List<Message> getUpdateMessages(Entity entity) {
+		List<Message> messages = new ArrayList<Message>(2);
 		/*if (entity.getController().data().isDirty()) {
 			msgs.add(new EntityDatatableMessage(entity.getId(), entity.getController().data()));
 		}*/
 
 		Transform current = entity.getTransform();
 		if (!current.equals(entity.getLastTransform())) {
-			msgs.add(new EntityPositionMessage(entity.getId(), current));
+			messages.add(new EntityPositionMessage(entity.getId(), current));
 		}
-
-		return msgs.toArray(new Message[msgs.size()]);
+		return messages;
 	}
 }

--- a/src/main/java/org/spout/engine/protocol/builtin/SpoutNetworkSynchronizer.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/SpoutNetworkSynchronizer.java
@@ -26,7 +26,9 @@
  */
 package org.spout.engine.protocol.builtin;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.spout.api.datatable.DataMap;
 import org.spout.api.entity.Entity;
@@ -84,24 +86,21 @@ public class SpoutNetworkSynchronizer extends NetworkSynchronizer {
 		return protocol;
 	}
 
-	public void spawnEntity(Entity e) {
+	@Override
+	public void syncEntity(Entity e, boolean spawn, boolean destroy, boolean update) {
 		EntityProtocol protocol = getEntityProtocol(e);
-		for (Message m : protocol.getSpawnMessage(e)) {
-			session.send(false, m);
+		List<Message> messages = new ArrayList<Message>(3);
+		if (destroy) {
+			messages.addAll(protocol.getDestroyMessages(e));
 		}
-	}
-
-	public void destroyEntity(Entity e) {
-		EntityProtocol protocol = getEntityProtocol(e);
-		for (Message m : protocol.getDestroyMessage(e)) {
-			session.send(false, m);
+		if (spawn) {
+			messages.addAll(protocol.getSpawnMessages(e));
 		}
-	}
-
-	public void syncEntity(Entity e) {
-		EntityProtocol protocol = getEntityProtocol(e);
-		for (Message m : protocol.getUpdateMessage(e)) {
-			session.send(false, m);
+		if (update) {
+			messages.addAll(protocol.getUpdateMessages(e));
+		}
+		for (Message message : messages) {
+			this.session.send(false, message);
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

Also prevents updating the same entity twice, and generates one list of messages to fill and re-use as buffer.

All pulls:
https://github.com/VanillaDev/Vanilla/pull/299
https://github.com/SpoutDev/SpoutAPI/pull/340
https://github.com/SpoutDev/Spout/pull/1974
