### PR TITLE
Fix, plugins-tofile folder "pluginreport"

### DIFF
--- a/src/main/java/org/spout/engine/command/TestCommands.java
+++ b/src/main/java/org/spout/engine/command/TestCommands.java
@@ -70,7 +70,7 @@ public class TestCommands {
 
         // File and filename
         String filename = "";
-        String standpath = "/pluginreports";
+        String standpath = "pluginreports";
         File file = null;
 
         // Getting date
@@ -95,7 +95,7 @@ public class TestCommands {
 
         // Create a new file
         try {
-            new File("/pluginreports").mkdirs();
+            new File("pluginreports").mkdirs();
             file.createNewFile();
         } catch (IOException e) {
             throw new CommandException("Couldn't create report-file!" + linesep + "Please make sure to only use valid chars in the filename.");


### PR DESCRIPTION
Those slashes were wrong, the folder was created in the root directory
of the filesystem/drive. Well fixed now.

Signed-off-by: Luca Moser moser.luca@gmail.com
