### PR TITLE
Fixed ChunkMeshBatch with MESH_COUNT != 1

### DIFF
--- a/src/main/java/org/spout/engine/batcher/ChunkMeshBatch.java
+++ b/src/main/java/org/spout/engine/batcher/ChunkMeshBatch.java
@@ -137,8 +137,7 @@ public class ChunkMeshBatch extends Cuboid {
 	}
 
 	private int getIndexFromChunkMesh(ChunkMesh chunkMesh) {
-		// TODO : Implement it if SIZE != 1
-		return 0;
+		return ( chunkMesh.getX() - getBase().getFloorX() ) * SIZE_Y * SIZE_Z + ( chunkMesh.getY() - getBase().getFloorY() ) * SIZE_Z + ( chunkMesh.getZ() - getBase().getFloorZ() );
 	}
 
 	public void addMesh(ChunkMesh chunkMesh) {

--- a/src/main/java/org/spout/engine/renderer/WorldRenderer.java
+++ b/src/main/java/org/spout/engine/renderer/WorldRenderer.java
@@ -100,7 +100,7 @@ public class WorldRenderer {
 		while( (chunkMesh = renderChunkMeshBatchQueue.poll()) != null){
 			Vector3 batchCoords = ChunkMeshBatch.getBatchCoordinates(new Vector3(chunkMesh.getX(), chunkMesh.getY(), chunkMesh.getZ()));
 			Vector3 chunkCoords = ChunkMeshBatch.getChunkCoordinates(batchCoords);
-			ChunkMeshBatch chunkMeshBatch = getChunkMeshBatchByChunkPosition(chunkCoords.getFloorX(), chunkCoords.getFloorY(), chunkCoords.getFloorZ());
+			ChunkMeshBatch chunkMeshBatch = getChunkMeshBatchByBatchPosition(batchCoords.getFloorX(), batchCoords.getFloorY(), batchCoords.getFloorZ());
 		
 			if(chunkMeshBatch==null){
 				if(!chunkMesh.hasVertices())
@@ -168,7 +168,7 @@ public class WorldRenderer {
 	 * @param y
 	 * @param z
 	 */
-	private ChunkMeshBatch getChunkMeshBatchByChunkPosition(int x, int y, int z) {
+	private ChunkMeshBatch getChunkMeshBatchByBatchPosition(int x, int y, int z) {
 		return chunkRenderersByPosition.get(x, y, z);
 	}
 


### PR DESCRIPTION
set in ChunkMeshBatch.java: getIndexFromChunkMesh function
return a unique Index for chunkMesh in meshes[]
fixed in WorldRenderer.java: getChunkMeshBatchByChunkPosition function
batchCoords instead of chunkCoords

Signed-off-by: Alkaelis AlkaelisFenaro@gmail.com
