### PR TITLE
Add VertexEffect

### DIFF
--- a/src/main/java/org/spout/engine/renderer/BufferContainer.java
+++ b/src/main/java/org/spout/engine/renderer/BufferContainer.java
@@ -29,16 +29,26 @@ package org.spout.engine.renderer;
 import java.util.HashMap;
 import java.util.Map;
 
+import gnu.trove.list.array.TFloatArrayList;
+
 public class BufferContainer {
-
 	public int element = 0;
-	final Map<Integer,Object> buffers = new HashMap<Integer,Object>();
+	final Map<Integer, Object> buffers = new HashMap<Integer, Object>();
 
-	public Map<Integer,Object> getBuffers(){
+	public Map<Integer, Object> getBuffers() {
 		return buffers;
 	}
 
-	public void setBuffers(int layout, Object buffer){
+	public Object getOrCreateBuffer(int layout) {
+		if (!buffers.containsKey(layout)) {
+			final TFloatArrayList buffer = new TFloatArrayList();
+			setBuffers(layout, buffer);
+			return buffer;
+		}
+		return buffers.get(layout);
+	}
+
+	public void setBuffers(int layout, Object buffer) {
 		buffers.put(layout, buffer);
 	}
 }

--- a/src/main/java/org/spout/engine/resources/ClientRenderMaterial.java
+++ b/src/main/java/org/spout/engine/resources/ClientRenderMaterial.java
@@ -30,23 +30,15 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.lwjgl.opengl.GL11;
-import org.spout.api.geo.cuboid.ChunkSnapshotModel;
-import org.spout.api.material.Material;
 import org.spout.api.math.Matrix;
 import org.spout.api.math.Vector2;
 import org.spout.api.math.Vector3;
 import org.spout.api.math.Vector4;
-import org.spout.api.model.mesh.Mesh;
-import org.spout.api.model.mesh.MeshFace;
-import org.spout.api.model.mesh.OrientedMesh;
-import org.spout.api.model.mesh.OrientedMeshFace;
-import org.spout.api.model.mesh.Vertex;
 import org.spout.api.render.RenderMaterial;
 import org.spout.api.render.Shader;
 import org.spout.api.render.effect.BatchEffect;
@@ -57,6 +49,7 @@ import org.spout.api.render.effect.SnapshotBatch;
 import org.spout.api.render.effect.SnapshotEntity;
 import org.spout.api.render.effect.SnapshotMesh;
 import org.spout.api.render.effect.SnapshotRender;
+import org.spout.api.render.effect.VertexEffect;
 
 public class ClientRenderMaterial extends RenderMaterial {
 
@@ -67,9 +60,10 @@ public class ClientRenderMaterial extends RenderMaterial {
 	Matrix view;
 	Matrix projection;
 	int layer;
-	private List<BatchEffect> batchEffects = new ArrayList<BatchEffect>();
-	private List<RenderEffect> renderEffects = new ArrayList<RenderEffect>();
-	private List<EntityEffect> entityEffects = new ArrayList<EntityEffect>();
+	private final List<BatchEffect> batchEffects = new ArrayList<BatchEffect>();
+	private final List<RenderEffect> renderEffects = new ArrayList<RenderEffect>();
+	private final List<EntityEffect> entityEffects = new ArrayList<EntityEffect>();
+	private final List<VertexEffect> vertexEffects = new ArrayList<VertexEffect>();
 
 	public ClientRenderMaterial(Shader s, Map<String, Object> params){
 		this(s, params, null, null, true, 0);
@@ -226,4 +220,25 @@ public class ClientRenderMaterial extends RenderMaterial {
 		entityEffects.add(entityEffect);
 	}
 
+	@Override
+	public Collection<VertexEffect> getVertexEffects() {
+		return Collections.unmodifiableCollection(vertexEffects);
+	}
+	
+	@Override
+	public boolean hasVertexEffects() {
+		return !vertexEffects.isEmpty();
+	}
+
+	@Override
+	public void addVertexEffect(VertexEffect effect) {
+		final int layout = effect.getLayout();
+		for (VertexEffect current : vertexEffects) {
+			if (current.getLayout() == layout) {
+				throw new IllegalArgumentException("Cannot add " + effect
+						+ ". Layout " + layout + " is already in use.");
+			}
+		}
+		vertexEffects.add(effect);
+	}
 }


### PR DESCRIPTION
Adds the ability to insert suplemental arbitrary vertex data taken from the world.

This data must be a float or float structure and interpretable by OpenGL (as matrices, vectors, etc.). This data is then passed to the vertex shader as an "in" variable.

The data is taken from one or more VertexEffect during addition of the vertex data to the buffers. Each VertexEffect gets its own buffer.

Each VertexEffect corresponds to one suplemental "in" variable for the vertex shader.

VertexEffects are added to RenderMaterials by plugins.

Related PR:
https://github.com/SpoutDev/SpoutAPI/pull/463

Example of usage:
Vanilla: https://github.com/VanillaDev/Vanilla/pull/408

Signed-off-by: Aleksi Sapon QcTechs@gmail.com
