### PR TITLE
Clear the console line as well

### DIFF
--- a/src/main/java/org/spout/engine/chat/console/JLineConsole.java
+++ b/src/main/java/org/spout/engine/chat/console/JLineConsole.java
@@ -101,7 +101,7 @@ public class JLineConsole extends AbstractConsole {
 	public void addMessage(ChatArguments message) {
 		try {
 			synchronized (writer) {
-				reader.printString(ConsoleOperations.RESET_LINE + "");
+				reader.printString(ConsoleOperations.RESET_LINE + "\033[K");
 				reader.flushConsole();
 				appendDateFormat(writer);
 				for (String line : stringify(message).split("\n")) {


### PR DESCRIPTION
Useful in the instance that the line from the console input buffer is larger than the incoming text to the jline console.

Kinda bothered me when I was developing BotSy and was tinkering with jline2, and I noticed that Spout suffered from the same effect. Really noticeable when you have a long command with a lot of parameters, and the console updates - you'll see it [isn't entirely cleared](http://puu.sh/1MgKy).
