### PR TITLE
Change bone vert shader to avoid code causing compiling errors on same ATI cards

### DIFF
--- a/src/main/resources/shaders/bones2b2a/bones.120.vert
+++ b/src/main/resources/shaders/bones2b2a/bones.120.vert
@@ -21,7 +21,8 @@ void main() {
 	vec4 bone_transform = vec4(0,0,0,0);
 
 	for (int i=0 ; i<2 ; ++i) {
-		bone_transform += bone_weights[i] * bone_matrix1[int(bone_ids[i])] * bone_matrix2[int(bone_ids[i])] * vPosition;
+		int bone_id = int(bone_ids[i]);
+		bone_transform += bone_weights[i] * bone_matrix1[bone_id] * bone_matrix2[bone_id] * vPosition;
 	}
 
 	gl_Position = Projection * View * Model * bone_transform;

--- a/src/main/resources/shaders/bones2b2a/bones.330.vert
+++ b/src/main/resources/shaders/bones2b2a/bones.330.vert
@@ -20,7 +20,8 @@ void main() {
 	vec4 bone_transform = vec4(0,0,0,0);
 
 	for (int i=0 ; i<2 ; ++i) {
-		bone_transform += bone_weights[i] * bone_matrix1[int(bone_ids[i])] * bone_matrix2[int(bone_ids[i])] * vPosition;
+		int bone_id = int(bone_ids[i]);
+		bone_transform += bone_weights[i] * bone_matrix1[bone_id] * bone_matrix2[bone_id] * vPosition;
 	}
 
 	gl_Position = Projection * View * Model * bone_transform;


### PR DESCRIPTION
My ati card, and possibly others, have a problem with the following
syntax: array1[function(array2[variable])] Replaceing the variable with a
constant will not cause the issue, but that specific syntax seems to cause
errors with some of the old ATI stuff. It may also be a problem with some
newer AMD cards, but that has zero evidence to back it up.
Signed-off-by: Unknownloner Unknownloner.Online@gmail.com
