### PR TITLE
Improved shader compile logging

### DIFF
--- a/src/main/java/org/spout/engine/renderer/shader/ClientShader.java
+++ b/src/main/java/org/spout/engine/renderer/shader/ClientShader.java
@@ -86,19 +86,19 @@ public class ClientShader extends Resource implements Shader {
 		public void run() {
 			doCompileShader(vsource,fsource);
 		}
-		
+
 		private void doCompileShader(String vsource, String fsource){
 			if (((Client) Spout.getEngine()).getRenderMode() == RenderMode.GL11) {
 				return;
 			}
 
-
 			//Create a new Shader object on the GPU
 			program = GL20.glCreateProgram();
 
+			System.out.println("Compiling ClientShader {ID=" + program + ", Frag=" + this.fsourceUrl + ", Vert=" + this.vsourceUrl + "}");
+
 			int vShader = ShaderHelper.compileShader(vsource, vsourceUrl, GL20.GL_VERTEX_SHADER);
 			GL20.glAttachShader(program, vShader);
-
 
 			int fShader = ShaderHelper.compileShader(fsource, fsourceUrl, GL20.GL_FRAGMENT_SHADER);
 			GL20.glAttachShader(program, fShader);
@@ -111,12 +111,6 @@ public class ClientShader extends Resource implements Shader {
 				throw new ShaderCompileException("Link Error in " + vsourceUrl + ", " + fsourceUrl +": " + error);
 			}
 			if (validateShader) {
-				GL20.glValidateProgram(shader.program);
-				if (GL20.glGetProgram(program, GL20.GL_VALIDATE_STATUS) != GL11.GL_TRUE) {
-					String info = GL20.glGetProgramInfoLog(program, 255);
-					System.out.println("Validate Log: \n" + info);
-				}
-
 				System.out.println("Attached Shaders: " + GL20.glGetProgram(program, GL20.GL_ATTACHED_SHADERS));
 				int activeAttributes = GL20.glGetProgram(program, GL20.GL_ACTIVE_ATTRIBUTES);
 				System.out.println("Active Attributes: " + activeAttributes);
@@ -131,9 +125,22 @@ public class ClientShader extends Resource implements Shader {
 				for (int i = 0; i < activeUniforms; i++) {
 					System.out.println("\t" + GL20.glGetActiveUniform(program, i, maxUniformLength));
 				}
+
+				// Show the log, info/warning based on whether validation was successful
+				// Print line by line to avoid botched time stamps
+				GL20.glValidateProgram(shader.program);
+				String[] logLines  = GL20.glGetProgramInfoLog(program, 255).split("\n");
+				if (GL20.glGetProgram(program, GL20.GL_VALIDATE_STATUS) == GL11.GL_TRUE) {
+					for (String line : logLines) {
+						Spout.getLogger().info(line.trim());
+					}
+				} else {
+					for (String line : logLines) {
+						Spout.getLogger().warning(line.trim());
+					}
+				}
 			}
 			SpoutRenderer.checkGLError();
-			System.out.println("Compiled Shader with id: " + program);
 		}
 	}
 	

--- a/src/main/java/org/spout/engine/resources/ClientTexture.java
+++ b/src/main/java/org/spout/engine/resources/ClientTexture.java
@@ -152,7 +152,6 @@ public class ClientTexture extends Texture {
 			//	GL30.glGenerateMipmap(textureID);
 			//}
 
-
 			GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
 			SpoutRenderer.checkGLError();
 


### PR DESCRIPTION
It appears to be the case that shaders can still contain several issues some video cards can deal with, but others can't. That validation is successful is no guarantee that the shader is 'sane'. In this commit, I improved the information logged 'about' the shader being compiled, and it always logs the full validation log. If validation fails, this log is a warning, otherwise it is info.

Additionally, I print the log line by line, because it results in botched time stamps otherwise. (an indent on the first line), which is nothing more but an aesthetic fix.
