### PR TITLE
Fixed invalid cast in shader and improved GL attribute type to name conversion

### DIFF
--- a/src/main/java/org/spout/engine/SpoutRenderer.java
+++ b/src/main/java/org/spout/engine/SpoutRenderer.java
@@ -26,6 +26,8 @@
  */
 package org.spout.engine;
 
+import gnu.trove.map.hash.TIntObjectHashMap;
+
 import java.awt.Canvas;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -391,6 +393,49 @@ public class SpoutRenderer {
 		} else {
 			GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
 			wireframe = true;
+		}
+	}
+
+	private static final TIntObjectHashMap<String> glTypeNames = new TIntObjectHashMap<String>();
+
+	private static void setGLTypeName(int typeId, String typeName) {
+		glTypeNames.put(typeId, typeName);
+	}
+
+	static {
+		setGLTypeName(GL20.GL_BOOL, "GL_BOOL");
+		setGLTypeName(GL20.GL_BOOL_VEC2, "GL_BOOL_VEC2");
+		setGLTypeName(GL20.GL_BOOL_VEC3, "GL_BOOL_VEC3");
+		setGLTypeName(GL20.GL_BOOL_VEC4, "GL_BOOL_VEC4");
+		setGLTypeName(GL20.GL_FLOAT_VEC2, "GL_FLOAT_VEC2");
+		setGLTypeName(GL20.GL_FLOAT_VEC3, "GL_FLOAT_VEC3");
+		setGLTypeName(GL20.GL_FLOAT_VEC4, "GL_FLOAT_VEC4");
+		setGLTypeName(GL20.GL_FLOAT_MAT2, "GL_FLOAT_MAT2");
+		setGLTypeName(GL20.GL_FLOAT_MAT3, "GL_FLOAT_MAT3");
+		setGLTypeName(GL20.GL_FLOAT_MAT4, "GL_FLOAT_MAT4");
+		setGLTypeName(GL20.GL_INT_VEC2, "GL_INT_VEC2");
+		setGLTypeName(GL20.GL_INT_VEC3, "GL_INT_VEC3");
+		setGLTypeName(GL20.GL_INT_VEC4, "GL_INT_VEC4");
+		setGLTypeName(GL20.GL_SAMPLER_1D, "GL_SAMPLER_1D");
+		setGLTypeName(GL20.GL_SAMPLER_1D_SHADOW, "GL_SAMPLER_1D_SHADOW");
+		setGLTypeName(GL20.GL_SAMPLER_2D, "GL_SAMPLER_2D");
+		setGLTypeName(GL20.GL_SAMPLER_2D_SHADOW, "GL_SAMPLER_2D_SHADOW");
+		setGLTypeName(GL20.GL_SAMPLER_3D, "GL_SAMPLER_3D");
+		setGLTypeName(GL20.GL_SAMPLER_CUBE, "GL_SAMPLER_CUBE");
+	}
+
+	/**
+	 * Gets the GL type name from a GL type identifier
+	 * 
+	 * @param glType to get the name of
+	 * @return The GL type name
+	 */
+	public static String getGLTypeName(int glType) {
+		String name = glTypeNames.get(glType);
+		if (name == null) {
+			return "UNKNOWN(" + glType + ")";
+		} else {
+			return name;
 		}
 	}
 

--- a/src/main/java/org/spout/engine/renderer/shader/ClientShader.java
+++ b/src/main/java/org/spout/engine/renderer/shader/ClientShader.java
@@ -209,73 +209,7 @@ public class ClientShader extends Resource implements Shader {
 
 		@Override
 		public String toString(){
-			String stype;
-
-			//Todo : Replace this swith by a magical OpenGLConstantToString() ?
-			switch (type) {
-			case GL20.GL_BOOL:
-				stype = "GL_BOOL";
-				break;
-			case GL20.GL_BOOL_VEC2:
-				stype = "GL_BOOL_VEC2";
-				break;
-			case GL20.GL_BOOL_VEC3:
-				stype = "GL_BOOL_VEC3";
-				break;
-			case GL20.GL_BOOL_VEC4:
-				stype = "GL_BOOL_VEC4";
-				break;
-			case GL20.GL_FLOAT_VEC2:
-				stype = "GL_FLOAT_VEC2";
-				break;
-			case GL20.GL_FLOAT_VEC3:
-				stype = "GL_FLOAT_VEC3";
-				break;
-			case GL20.GL_FLOAT_VEC4:
-				stype = "GL_FLOAT_VEC4";
-				break;
-			case GL20.GL_FLOAT_MAT2:
-				stype = "GL_FLOAT_MAT2";
-				break;
-			case GL20.GL_FLOAT_MAT3:
-				stype = "GL_FLOAT_MAT3";
-				break;
-			case GL20.GL_FLOAT_MAT4:
-				stype = "GL_FLOAT_MAT4";
-				break;
-			case GL20.GL_INT_VEC2:
-				stype = "GL_INT_VEC2";
-				break;
-			case GL20.GL_INT_VEC3:
-				stype = "GL_INT_VEC3";
-				break;
-			case GL20.GL_INT_VEC4:
-				stype = "GL_INT_VEC4";
-				break;
-			case GL20.GL_SAMPLER_1D:
-				stype = "GL_SAMPLER_1D";
-				break;
-			case GL20.GL_SAMPLER_1D_SHADOW:
-				stype = "GL_SAMPLER_1D_SHADOW";
-				break;
-			case GL20.GL_SAMPLER_2D:
-				stype = "GL_SAMPLER_2D";
-				break;
-			case GL20.GL_SAMPLER_2D_SHADOW:
-				stype = "GL_SAMPLER_2D_SHADOW";
-				break;
-			case GL20.GL_SAMPLER_3D:
-				stype = "GL_SAMPLER_3D";
-				break;
-			case GL20.GL_SAMPLER_CUBE:
-				stype = "GL_SAMPLER_CUBE";
-				break;
-			default:
-				stype = "unknow";
-				break;
-			}
-
-			return name + " type:" + stype + (size == 1 ? "" : "[" + size + "]");
+			return name + " type:" + SpoutRenderer.getGLTypeName(type) + (size == 1 ? "" : "[" + size + "]");
 		}
 	}
 

--- a/src/main/java/org/spout/engine/resources/ClientTexture.java
+++ b/src/main/java/org/spout/engine/resources/ClientTexture.java
@@ -58,7 +58,7 @@ public class ClientTexture extends Texture {
 	}
 
 	public int getTextureID() {
-		if (textureID == -1) {
+		if (!isLoaded()) {
 			throw new IllegalStateException("Cannot use an unloaded texture");
 		}
 		return textureID;
@@ -66,7 +66,7 @@ public class ClientTexture extends Texture {
 
 	@Override
 	public void bind() {
-		if (isLoaded()) {
+		if (!isLoaded()) {
 			throw new IllegalStateException("Cannot bind an unloaded texture!");
 		}
 		GL11.glEnable(GL11.GL_TEXTURE_2D);
@@ -76,8 +76,7 @@ public class ClientTexture extends Texture {
 	}
 
 	public void unload() {
-		
-		if (textureID == -1) {
+		if (!isLoaded()) {
 			throw new IllegalStateException("Cannot delete an unloaded texture!");
 		}
 
@@ -162,7 +161,7 @@ public class ClientTexture extends Texture {
 
 	@Override
 	public void writeGPU() {
-		if (textureID != -1) {
+		if (isLoaded()) {
 			throw new IllegalStateException("Cannot load an already loaded texture!");
 		}
 		((SpoutClient) Spout.getEngine()).getScheduler().enqueueRenderTask(new WriteGPUTask(getWidth(),getHeight(),this.image));

--- a/src/main/resources/shaders/gui.basic.330.vert
+++ b/src/main/resources/shaders/gui.basic.330.vert
@@ -18,9 +18,9 @@ void main() {
 	model[3][0] = model[2][0];
 	model[3][1] = model[2][1];
 	model[3][2] = model[2][2];
-	model[2][0] = 0;
-	model[2][1] = 0;
-	model[2][2] = 1;
+	model[2][0] = 0.0;
+	model[2][1] = 0.0;
+	model[2][2] = 1.0;
 	gl_Position = Projection * View * mat4(model) * vPosition;
 	
 	uvcoord = vTexCoord;


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

The huge switch statement was a bit hidden, it can be possible that types need to be evaluated in other locations as well. An IntObjectHashMap is used to map GL type IDs to their respective names.
