### PR TITLE
Only listen to mouse input if display is active

### DIFF
--- a/src/main/java/org/spout/engine/input/SpoutInputManager.java
+++ b/src/main/java/org/spout/engine/input/SpoutInputManager.java
@@ -30,6 +30,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.lwjgl.opengl.Display;
+
 import org.spout.api.Client;
 import org.spout.api.Engine;
 import org.spout.api.Spout;
@@ -149,7 +151,7 @@ public class SpoutInputManager implements InputManager {
 		}
 
 		// Handle mouse
-		if (org.lwjgl.input.Mouse.isCreated()) {
+		if (org.lwjgl.input.Mouse.isCreated() && Display.isActive()) {
 			int x, y;
 			while (org.lwjgl.input.Mouse.next()) {
 


### PR DESCRIPTION
Prevents the camera for moving if the client's window is not focused.
Signed-off-by: Steven Downer grinch@outlook.com
