### PR TITLE
Fixing the chunk meshing

### DIFF
--- a/src/main/java/org/spout/engine/SpoutClient.java
+++ b/src/main/java/org/spout/engine/SpoutClient.java
@@ -156,7 +156,6 @@ public class SpoutClient extends SpoutEngine implements Client {
 		}
 		// Send handshake message first
 		SpoutClientSession get = session.get();
-		getPlayer().getName();
 		get.send(true, get.getProtocol().getIntroductionMessage(getPlayer().getName(), (InetSocketAddress) get.getChannel().getRemoteAddress()));
 
 		super.start();
@@ -168,6 +167,8 @@ public class SpoutClient extends SpoutEngine implements Client {
 		AnnotatedCommandExecutorFactory.create(new RendererCommands(this));
 
 		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
+
+		getScheduler().startMeshThread();
 		this.renderer = getScheduler().startRenderThread(new Vector2(dim.getWidth() * 0.75f, dim.getHeight() * 0.75f), ccoverride, null);
 		getScheduler().startGuiThread();
 
@@ -215,7 +216,7 @@ public class SpoutClient extends SpoutEngine implements Client {
 			session.getProtocol().initializeClientSession(session);
 
 			// TODO this is really unclean
-			final SpoutClientPlayer p = new SpoutClientPlayer(this, "Spouty", new Transform().setPosition(new Point(getWorld(), 0, 0, 0)), SpoutConfiguration.VIEW_DISTANCE.getInt() * Chunk.BLOCKS.SIZE);
+			final SpoutClientPlayer p = new SpoutClientPlayer(this, "Spouty", new Transform().setPosition(new Point(getWorld(), 1, 200, 1)), SpoutConfiguration.VIEW_DISTANCE.getInt() * Chunk.BLOCKS.SIZE);
 			if (!p.connect(session, p.getScene().getTransform())) {
 				getLogger().log(Level.SEVERE, "Error in calling player connect");
 				return false;
@@ -474,4 +475,9 @@ public class SpoutClient extends SpoutEngine implements Client {
 		return session.get();
 	}
 
+	@Override
+	public void copySnapshotRun() {
+		super.copySnapshotRun();
+		getPlayer().copySnapshot();
+	}
 }

--- a/src/main/java/org/spout/engine/SpoutRenderer.java
+++ b/src/main/java/org/spout/engine/SpoutRenderer.java
@@ -78,6 +78,7 @@ import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
 import org.spout.api.Spout;
+import org.spout.engine.world.SpoutChunk;
 
 public class SpoutRenderer {
 
@@ -121,6 +122,8 @@ public class SpoutRenderer {
 		this.entityRenderer = new EntityRenderer();
 
 		this.ccoverride = ccoverride;
+		
+		worldRenderer = new WorldRenderer();
 	}
 
 	public void initRenderer(Canvas parent) {
@@ -162,8 +165,6 @@ public class SpoutRenderer {
 
 		//Init pool of BatchVertexRenderer
 		BatchVertexRenderer.initPool(GL11.GL_TRIANGLES, 10000);
-
-		worldRenderer = new WorldRenderer();
 
 		if (useReflexion) {
 			reflected = new ClientRenderTexture(true, false, true);
@@ -303,17 +304,21 @@ public class SpoutRenderer {
 
 		//GUI -> Update debug info
 		if (showDebugInfos) {
+			int id = 0;
 			Point position = client.getPlayer().getScene().getPosition();
-			debugScreen.spoutUpdate(0, "Spout client! Logged as " + client.getPlayer().getDisplayName() + " in world: " + client.getWorld().getName());
-			debugScreen.spoutUpdate(1, "x: " + position.getX() + "y: " + position.getY() + "z: " + position.getZ());
-			debugScreen.spoutUpdate(2, "FPS: " + client.getScheduler().getFps() + " (" + (client.getScheduler().isRendererOverloaded() ? "Overloaded" : "Normal") + ")");
-			debugScreen.spoutUpdate(3, "Chunks Loaded: " + client.getWorld().getNumLoadedChunks());
-			debugScreen.spoutUpdate(4, "Chunks Drawn: " + ((int) ((float) worldRenderer.getRenderedChunks() / (float) (worldRenderer.getTotalChunks()) * 100)) + "%" + " (" + worldRenderer.getRenderedChunks() + ")");
-			debugScreen.spoutUpdate(5, "Occluded Chunks: " + (int) ((float) worldRenderer.getOccludedChunks() / worldRenderer.getTotalChunks() * 100) + "% (" + worldRenderer.getOccludedChunks() + ")");
-			debugScreen.spoutUpdate(6, "Cull Chunks: " + (int) ((float) worldRenderer.getCulledChunks() / worldRenderer.getTotalChunks() * 100) + "% (" + worldRenderer.getCulledChunks() + ")");
-			debugScreen.spoutUpdate(7, "Entities: " + entityRenderer.getRenderedEntities());
-			debugScreen.spoutUpdate(8, "Buffer: " + worldRenderer.addedBatch + " / " + worldRenderer.updatedBatch);
-			debugScreen.spoutUpdate(9, "Time: " + worldTime / 1000000.0 + " / " + entityTime / 1000000.0 + " / " + guiTime / 1000000.0);
+			debugScreen.spoutUpdate(id++, "Spout client! Logged as " + client.getPlayer().getDisplayName() + " in world: " + client.getWorld().getName());
+			debugScreen.spoutUpdate(id++, "x: " + position.getX() + "y: " + position.getY() + "z: " + position.getZ());
+			debugScreen.spoutUpdate(id++, "FPS: " + client.getScheduler().getFps() + " (" + (client.getScheduler().isRendererOverloaded() ? "Overloaded" : "Normal") + ")");
+			debugScreen.spoutUpdate(id++, "Chunks Loaded: " + client.getWorld().getNumLoadedChunks());
+			debugScreen.spoutUpdate(id++, "Total Chunks in Renderer: " + worldRenderer.getTotalChunks() + "");
+			debugScreen.spoutUpdate(id++, "Chunks Drawn: " + ((int) ((float) worldRenderer.getRenderedChunks() / (float) (worldRenderer.getTotalChunks()) * 100)) + "%" + " (" + worldRenderer.getRenderedChunks() + ")");
+			debugScreen.spoutUpdate(id++, "Occluded Chunks: " + (int) ((float) worldRenderer.getOccludedChunks() / worldRenderer.getTotalChunks() * 100) + "% (" + worldRenderer.getOccludedChunks() + ")");
+			debugScreen.spoutUpdate(id++, "Cull Chunks: " + (int) ((float) worldRenderer.getCulledChunks() / worldRenderer.getTotalChunks() * 100) + "% (" + worldRenderer.getCulledChunks() + ")");
+			debugScreen.spoutUpdate(id++, "Entities: " + entityRenderer.getRenderedEntities());
+			debugScreen.spoutUpdate(id++, "Buffer: " + worldRenderer.addedBatch + " / " + worldRenderer.updatedBatch);
+			debugScreen.spoutUpdate(id++, "Time: " + worldTime / 1000000.0 + " / " + entityTime / 1000000.0 + " / " + guiTime / 1000000.0);
+			debugScreen.spoutUpdate(id++, "Chunk render(): " + SpoutChunk.renderAmount.get());
+			debugScreen.spoutUpdate(id++, "Mesh batch queue size: " + ((SpoutClient) Spout.getEngine()).getRenderer().getWorldRenderer().getBatchWaiting());
 		}
 		
 		for (Screen screen : screenStack.getVisibleScreens()) {

--- a/src/main/java/org/spout/engine/SpoutServer.java
+++ b/src/main/java/org/spout/engine/SpoutServer.java
@@ -771,7 +771,7 @@ public class SpoutServer extends SpoutEngine implements Server {
 		boolean created = false;
 		if (player == null) {
 			getLogger().info("First login for " + playerName + ", creating new player data");
-			player = new SpoutPlayer(this, playerName, null, viewDistance);
+			player = new SpoutPlayer(this, playerName, ((SpoutServerWorld) getDefaultWorld()).getSpawnPoint(), viewDistance);
 			created = true;
 		}
 		SpoutPlayer oldPlayer = players.put(playerName, player);

--- a/src/main/java/org/spout/engine/batcher/ChunkMeshBatchAggregator.java
+++ b/src/main/java/org/spout/engine/batcher/ChunkMeshBatchAggregator.java
@@ -68,18 +68,20 @@ public class ChunkMeshBatchAggregator extends Cuboid {
 	}
 
 	public static Vector3 getBaseFromChunkMesh(ChunkMesh mesh) {
-		Vector3 v = new Vector3(Math.floor((float)mesh.getChunkX() / ChunkMeshBatchAggregator.SIZE_X) * ChunkMeshBatchAggregator.SIZE_X,
-				Math.floor((float)mesh.getChunkY() / ChunkMeshBatchAggregator.SIZE_Y) * ChunkMeshBatchAggregator.SIZE_Y,
-				Math.floor((float)mesh.getChunkZ() / ChunkMeshBatchAggregator.SIZE_Z) * ChunkMeshBatchAggregator.SIZE_Z);
-		return v;
+		int x = (int) (Math.floor((float)mesh.getChunkX() / ChunkMeshBatchAggregator.SIZE_X) * ChunkMeshBatchAggregator.SIZE_X);
+		int y = (int) (Math.floor((float)mesh.getChunkY() / ChunkMeshBatchAggregator.SIZE_Y) * ChunkMeshBatchAggregator.SIZE_Y);
+		int z = (int) (Math.floor((float)mesh.getChunkZ() / ChunkMeshBatchAggregator.SIZE_Z) * ChunkMeshBatchAggregator.SIZE_Z);
+		return new Vector3(x, y, z);
 	}
 
+	// TODO: this wasn't being used correctly, I think
+	/*
 	public static Vector3 getCoordFromChunkMesh(ChunkMesh mesh) {
 		Vector3 v = new Vector3(Math.floor((float)mesh.getChunkX() / ChunkMeshBatchAggregator.SIZE_X),
 				Math.floor((float)mesh.getChunkY() / ChunkMeshBatchAggregator.SIZE_Y),
 				Math.floor((float)mesh.getChunkZ() / ChunkMeshBatchAggregator.SIZE_Z));
-		return v;
-	}
+		return v;	
+	}*/
 
 	public ChunkMeshBatchAggregator(World world, int x, int y, int z, RenderMaterial material) {
 		super(new Point(world, x << Chunk.BLOCKS.BITS, y << Chunk.BLOCKS.BITS, z << Chunk.BLOCKS.BITS), SIZE.multiply(Chunk.BLOCKS.SIZE));
@@ -128,7 +130,7 @@ public class ChunkMeshBatchAggregator extends Cuboid {
 		else if(bufferContainer != null && this.bufferContainer[index] == null)
 			count++;
 		
-		this.bufferContainer[getIndex(x, y, z)] = bufferContainer;
+		this.bufferContainer[index] = bufferContainer;
 		dataSent = false;
 	}
 

--- a/src/main/java/org/spout/engine/entity/SpoutEntity.java
+++ b/src/main/java/org/spout/engine/entity/SpoutEntity.java
@@ -87,7 +87,7 @@ public class SpoutEntity extends BaseComponentOwner implements Entity, Snapshota
 	private boolean observeChunksFailed = false;
 	private final SnapshotableBoolean save = new SnapshotableBoolean(snapshotManager, false);
 	private final AtomicInteger id = new AtomicInteger(NOTSPAWNEDID);
-	private final SnapshotableInt viewDistance = new SnapshotableInt(snapshotManager, 10);
+	private final SnapshotableInt viewDistance = new SnapshotableInt(snapshotManager, 5);
 	private volatile boolean remove = false;
 	//Other
 	private final Engine engine;

--- a/src/main/java/org/spout/engine/protocol/builtin/SpoutServerNetworkSynchronizer.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/SpoutServerNetworkSynchronizer.java
@@ -61,7 +61,7 @@ public class SpoutServerNetworkSynchronizer extends ServerNetworkSynchronizer {
 
 	@Override
 	protected void freeChunk(Point p) {
-		session.send(new ChunkDataMessage(p.getBlockX(), p.getBlockY(), p.getBlockZ()));
+		session.send(new ChunkDataMessage(p.getChunkX(), p.getChunkY(), p.getChunkZ()));
 	}
 
 	@Override
@@ -93,7 +93,7 @@ public class SpoutServerNetworkSynchronizer extends ServerNetworkSynchronizer {
 		}
 		if (update) {
 			// TODO - might be worth adding force support
-			messages.addAll(protocol.getUpdateMessages(e, liveTransform, getRepositionManager(), false));
+			messages.addAll(protocol.getUpdateMessages(e, liveTransform, getRepositionManager(), true));
 		}
 		for (Message message : messages) {
 			this.session.send(message);

--- a/src/main/java/org/spout/engine/protocol/builtin/handler/ChunkDataMessageHandler.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/handler/ChunkDataMessageHandler.java
@@ -58,7 +58,7 @@ public class ChunkDataMessageHandler extends MessageHandler<ChunkDataMessage> {
 			throw new IllegalArgumentException("Unknown biome manager class: " + message.getBiomeManagerClass());
 		}*/
 		if (Spout.debugMode()) {
-			Spout.getLogger().log(Level.INFO, "Recieved Chunk Data: {0}", message.toString());
+			//Spout.getLogger().log(Level.INFO, "Recieved Chunk Data: {0}", message.toString());
 		}/*
 		BiomeManager manager;
 		try {
@@ -73,7 +73,6 @@ public class ChunkDataMessageHandler extends MessageHandler<ChunkDataMessage> {
 			throw new RuntimeException(e);
 		}
 		manager.deserialize(message.getBiomeData());*/
-		//((SpoutClientWorld) world).addChunk(message.getX(), message.getY(), message.getZ(), message.getBlockIds(), message.getBlockData(), manager);
 		((SpoutClientWorld) world).addChunk(message.getX(), message.getY(), message.getZ(), message.getBlockIds(), message.getBlockData());
 	}
 }

--- a/src/main/java/org/spout/engine/protocol/builtin/handler/EntityTransformMessageHandler.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/handler/EntityTransformMessageHandler.java
@@ -36,19 +36,17 @@ import org.spout.engine.protocol.builtin.message.EntityTransformMessage;
 public class EntityTransformMessageHandler extends MessageHandler<EntityTransformMessage> {
 	@Override
 	public void handleClient(ClientSession session, EntityTransformMessage message) {
-		if(!session.hasPlayer()) {
-			return;
-		}
-
 		RepositionManager rmInverse = session.getNetworkSynchronizer().getRepositionManager().getInverse();
 
+		System.out.println("Received Entity Transform " + message.getEntityId());
 		Entity entity;
 		if (message.getEntityId() == session.getDataMap().get(SpoutProtocol.PLAYER_ENTITY_ID)) {
+			System.out.println("Received Player Transform");
 			entity = session.getPlayer();
 		} else {
 			entity = session.getEngine().getDefaultWorld().getEntity(message.getEntityId());
 		}
-
+		System.out.println("(" +message.getTransform().getPosition().getX() + ", " + message.getTransform().getPosition().getY() + ", " + message.getTransform().getPosition().getZ() + ")");
 		if (entity != null) {
 			entity.getScene().setTransform(rmInverse.convert(message.getTransform()));
 		}

--- a/src/main/java/org/spout/engine/protocol/builtin/handler/LoginMessageHandler.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/handler/LoginMessageHandler.java
@@ -48,6 +48,7 @@ public class LoginMessageHandler extends MessageHandler<LoginMessage> {
 
 	@Override
 	public void handleClient(ClientSession session, LoginMessage message) {
+		System.out.println("Player ID Received: " + message.getExtraInt());
 		session.getDataMap().put(SpoutProtocol.PLAYER_ENTITY_ID, message.getExtraInt());
 		session.setState(Session.State.GAME);
 		session.getEngine().getEventManager().callEvent(new ClientPlayerConnectedEvent(session, message.getExtraInt()));

--- a/src/main/java/org/spout/engine/protocol/builtin/message/ChunkDataMessage.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/message/ChunkDataMessage.java
@@ -35,7 +35,7 @@ import org.spout.api.util.SpoutToStringStyle;
 
 public class ChunkDataMessage extends SpoutMessage {
 	private final boolean unload;
-	// Block x, y, z
+	// Chunk x, y, z
 	private final int x, y, z;
 	private final short[] blockIds, blockData;
 	// TODO remove biome info; client doesn't use it

--- a/src/main/java/org/spout/engine/protocol/builtin/message/EntityTransformMessage.java
+++ b/src/main/java/org/spout/engine/protocol/builtin/message/EntityTransformMessage.java
@@ -52,6 +52,7 @@ public class EntityTransformMessage extends SpoutMessage {
 
 	// Don't use this for tests; transform's position is stored as a Point which is NOT a Vector3 by equals
 	public EntityTransformMessage(int entityId, Transform transform, RepositionManager rm) {
+		System.out.println("Sending player transform " + entityId);
 		this.entityId = entityId;
 		this.worldUid = transform.getPosition().getWorld().getUID();
 		this.pos = rm.convert(transform.getPosition());

--- a/src/main/java/org/spout/engine/renderer/GLBufferContainer.java
+++ b/src/main/java/org/spout/engine/renderer/GLBufferContainer.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class GLBufferContainer {
+
 	public int element = 0;
 	int[] verticeIndex;
 	final Map<Integer,Buffer> buffers = new HashMap<Integer,Buffer>();

--- a/src/main/java/org/spout/engine/world/SpoutClientWorld.java
+++ b/src/main/java/org/spout/engine/world/SpoutClientWorld.java
@@ -62,8 +62,8 @@ public class SpoutClientWorld extends SpoutWorld {
 		addChunk(c.getX(), c.getY(), c.getZ(), c.getBlockIds(), c.getBlockData());
 	}
 
-	public void addChunk(int x, int y, int z, short[] blockIds, short[] blockData) {
-		getRegionFromBlock(x, y, z, LoadOption.LOAD_GEN).addChunk(x >> Region.CHUNKS.BITS, y >> Region.CHUNKS.BITS, z >> Region.CHUNKS.BITS, blockIds, blockData);
+	public void addChunk(int chunkX, int chunkY, int chunkZ, short[] blockIds, short[] blockData) {
+		getRegionFromBlock(chunkX, chunkY, chunkZ, LoadOption.LOAD_GEN).addChunk(chunkX, chunkY, chunkZ, blockIds, blockData).render();
 	}
 
 	@Override

--- a/src/main/java/org/spout/engine/world/SpoutServerWorld.java
+++ b/src/main/java/org/spout/engine/world/SpoutServerWorld.java
@@ -117,7 +117,7 @@ public class SpoutServerWorld extends SpoutWorld implements AsyncManager {
 		regionFileManager = new RegionFileManager(worldDirectory);
 
 		this.age = new SnapshotableLong(snapshotManager, age);
-		spawnLocation.set(new Transform(new Point(this, 1, 100, 1), Quaternion.IDENTITY, Vector3.ONE));
+		spawnLocation.set(new Transform(new Point(this, 1, 20, 1), Quaternion.IDENTITY, Vector3.ONE));
 		selfReference = new WeakReference<SpoutServerWorld>(this);
 		
 		taskManager = new SpoutTaskManager(getEngine().getScheduler(), null, this, age);


### PR DESCRIPTION
This is not working correctly, but it is far better than it was.

What needs to be done (sort of in order):
- (DONE) Figure out why every block in a ChunkMesh is always fully occluded (toRender[] is completely all false). If these become true, then chunks will start rendering again.
  - I've figured out why this is. A block's occlusion means it's opaque, therefore rendered (as compared to transparent). The renderer was trying to do the opposite. (Why is this not wrong in master?)
  - Wait, I realized that it checks the NEIGHBOR'S occlusion. In that case, it should be working correctly.
  - UNGENERATED in BlockMaterial needs to be transparent. Did anyone test master with the fallback world?
- Fix the OutOfMemoryError. I'm pretty sure this isn't a memory leak, but instead just trying to add too many block vertices (ones not needed). I think toRender[] is supposed to take those out, but I don't see how.
  - With toRender[] working correctly, no longer is EVERY vertex being rendered. Therefore, there's no OOME, but there is VERY high memory usage.
  - I'm pretty sure the reason for this now is that when a new chunk is adding, neighboring chunks' meshes are updated, causing edge blocks to become occluded.
- (DONE) Change MeshGeneratorRunnable to be a single thread in SpoutScheduler that reads SpoutChunkSnapshotModels
- Change the MeshGeneratorThread from a single thread to a pool of threads to allow for concurrent mesh generation.
- Figure out why the client player is not getting teleported to the correct server location. I think this might be part of the problem. (but not likely)

http://imgur.com/DVSC7ql
http://imgur.com/M1ezPi5
Initiate the applause.

Signed-off-by: Jack Huey kitskub@gmail.com
@Afforess
@Zidane
@DDoS
SpoutAPI: https://github.com/SpoutDev/SpoutAPI/pull/568
