### PR TITLE
More fixing of chunk meshing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<compilerArguments>
 						<O>-Xlint:all</O>
 						<O>-Xlint:-path</O>

--- a/src/main/java/org/spout/engine/SpoutRenderer.java
+++ b/src/main/java/org/spout/engine/SpoutRenderer.java
@@ -78,6 +78,7 @@ import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
 import org.spout.api.Spout;
+import org.spout.engine.mesh.ChunkMesh;
 import org.spout.engine.world.SpoutChunk;
 
 public class SpoutRenderer {
@@ -310,14 +311,14 @@ public class SpoutRenderer {
 			debugScreen.spoutUpdate(id++, "x: " + position.getX() + "y: " + position.getY() + "z: " + position.getZ());
 			debugScreen.spoutUpdate(id++, "FPS: " + client.getScheduler().getFps() + " (" + (client.getScheduler().isRendererOverloaded() ? "Overloaded" : "Normal") + ")");
 			debugScreen.spoutUpdate(id++, "Chunks Loaded: " + client.getWorld().getNumLoadedChunks());
-			debugScreen.spoutUpdate(id++, "Total Chunks in Renderer: " + worldRenderer.getTotalChunks() + "");
+			debugScreen.spoutUpdate(id++, "Total ChunkMeshBatchAggregators in Renderer: " + worldRenderer.getTotalChunks() + "");
 			debugScreen.spoutUpdate(id++, "Chunks Drawn: " + ((int) ((float) worldRenderer.getRenderedChunks() / (float) (worldRenderer.getTotalChunks()) * 100)) + "%" + " (" + worldRenderer.getRenderedChunks() + ")");
 			debugScreen.spoutUpdate(id++, "Occluded Chunks: " + (int) ((float) worldRenderer.getOccludedChunks() / worldRenderer.getTotalChunks() * 100) + "% (" + worldRenderer.getOccludedChunks() + ")");
 			debugScreen.spoutUpdate(id++, "Cull Chunks: " + (int) ((float) worldRenderer.getCulledChunks() / worldRenderer.getTotalChunks() * 100) + "% (" + worldRenderer.getCulledChunks() + ")");
 			debugScreen.spoutUpdate(id++, "Entities: " + entityRenderer.getRenderedEntities());
 			debugScreen.spoutUpdate(id++, "Buffer: " + worldRenderer.addedBatch + " / " + worldRenderer.updatedBatch);
 			debugScreen.spoutUpdate(id++, "Time: " + worldTime / 1000000.0 + " / " + entityTime / 1000000.0 + " / " + guiTime / 1000000.0);
-			debugScreen.spoutUpdate(id++, "Chunk render(): " + SpoutChunk.renderAmount.get());
+			debugScreen.spoutUpdate(id++, "Meshes generated: " + SpoutChunk.meshesGenerated.get());
 			debugScreen.spoutUpdate(id++, "Mesh batch queue size: " + ((SpoutClient) Spout.getEngine()).getRenderer().getWorldRenderer().getBatchWaiting());
 		}
 		

--- a/src/main/java/org/spout/engine/batcher/ChunkMeshBatchAggregator.java
+++ b/src/main/java/org/spout/engine/batcher/ChunkMeshBatchAggregator.java
@@ -109,15 +109,6 @@ public class ChunkMeshBatchAggregator extends Cuboid {
 	}
 
 	@Override
-	public void finalize() throws Throwable {
-		try {
-			renderer.release();
-		} finally {
-			super.finalize();
-		}
-	}
-
-	@Override
 	public String toString() {
 		return "ChunkMeshBatch [base=" + getBase() + ", size=" + getSize() + "]";
 	}

--- a/src/main/java/org/spout/engine/renderer/BatchVertexRenderer.java
+++ b/src/main/java/org/spout/engine/renderer/BatchVertexRenderer.java
@@ -202,6 +202,7 @@ public abstract class BatchVertexRenderer implements Renderer {
 	 */
 	@Override
 	protected void finalize() throws Throwable {
+		release();
 		super.finalize();
 	}
 

--- a/src/main/java/org/spout/engine/world/SpoutChunkSnapshotModel.java
+++ b/src/main/java/org/spout/engine/world/SpoutChunkSnapshotModel.java
@@ -217,13 +217,43 @@ public class SpoutChunkSnapshotModel implements ChunkSnapshotModel, Comparable<S
 		}
 	}
 	
-	@Override
+	/*@Override
 	public boolean equals(Object o) {
 		if (o == this) {
-			return true;
+		return true;
 		} else {
-			return id == ((SpoutChunkSnapshotModel) o).id;
+		return id == ((SpoutChunkSnapshotModel) o).id;
 		}
+	}*/
+
+	@Override
+	public int hashCode() {
+		int hash = 5;
+		hash = 67 * hash + this.cx;
+		hash = 67 * hash + this.cy;
+		hash = 67 * hash + this.cz;
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final SpoutChunkSnapshotModel other = (SpoutChunkSnapshotModel) obj;
+		if (this.cx != other.cx) {
+			return false;
+		}
+		if (this.cy != other.cy) {
+			return false;
+		}
+		if (this.cz != other.cz) {
+			return false;
+		}
+		return true;
 	}
 
 	public void addDirty(SpoutChunkSnapshotModel oldModel, boolean oldRemoved){

--- a/src/main/java/org/spout/engine/world/SpoutRegion.java
+++ b/src/main/java/org/spout/engine/world/SpoutRegion.java
@@ -241,7 +241,9 @@ public class SpoutRegion extends Region implements AsyncManager {
 		if (Spout.getPlatform() == Platform.CLIENT && (loadopt.loadIfNeeded() || loadopt.generateIfNeeded())) {
 			short[] blocks = new short[16 * 16 * 16];
 			Arrays.fill(blocks, BlockMaterial.UNGENERATED.getId());
-			return new SpoutChunk(getWorld(), this, getChunkX() + x, getChunkY() + y, getChunkZ() +  z, SpoutChunk.PopulationState.UNTOUCHED, blocks, null, null, true);
+			SpoutChunk newChunk = new SpoutChunk(getWorld(), this, getChunkX() + x, getChunkY() + y, getChunkZ() +  z, SpoutChunk.PopulationState.UNTOUCHED, blocks, null, null, true);
+			chunks[x][y][z].set(newChunk);
+			return newChunk;
 		}
 		
 		if (Spout.getPlatform() == Platform.CLIENT) {


### PR DESCRIPTION
With this change, the OOME is fixed. 
The problem was actually in SpoutAPI: UNGENERATED should be invisible, not transparent. (It might be worth it in the future to check occlusion for each face). 
This pull also causes new chunks to cause a regeneration of it's neighbors.
Also, there are now 4 mesh threads instead of one for concurrency.

SpoutAPI: https://github.com/SpoutDev/SpoutAPI/pull/569

@Afforess
Signed-off-by: Jack Huey kitskub@gmail.com
