### PR TITLE
Add version command

### DIFF
--- a/src/main/java/org/spout/engine/SpoutEngine.java
+++ b/src/main/java/org/spout/engine/SpoutEngine.java
@@ -159,7 +159,7 @@ public abstract class SpoutEngine implements AsyncManager, Engine {
 
 	public void start() {
 		Spout.info("Spout is starting in {0}-only mode.", getPlatform().name().toLowerCase());
-		Spout.info("Current version is {0} (Implementing SpoutAPI {1}).", getVersion(), getAPIVersion());
+		Spout.info("This server is running Spout #{0}.", Spout.getAPIVersion().replace("dev b", ""));
 		Spout.info("This software is currently in alpha status so components may");
 		Spout.info("have bugs or not work at all. Please report any issues to");
 		Spout.info("http://issues.spout.org");

--- a/src/main/java/org/spout/engine/command/CommonCommands.java
+++ b/src/main/java/org/spout/engine/command/CommonCommands.java
@@ -27,6 +27,7 @@
 package org.spout.engine.command;
 
 import org.spout.api.Server;
+import org.spout.api.Spout;
 import org.spout.api.command.CommandArguments;
 import org.spout.api.command.CommandBatch;
 import org.spout.api.command.CommandSource;
@@ -68,6 +69,7 @@ public class CommonCommands {
 	}
 
 	@CommandDescription(aliases = {"bat", "batch"}, usage = "<file>", desc = "Executes a Spout batch file.")
+	@Permissible("spout.command.batch")
 	public void batch(CommandSource source, CommandArguments args) throws CommandException {
 		String fileName = args.popString("file");
 		args.assertCompletelyParsed();
@@ -266,5 +268,11 @@ public class CommonCommands {
 		if (engine.getPlatform() == org.spout.api.Platform.SERVER) {
 			player.getData().put(MovementValidator.VALIDATE_MOVEMENT, !player.getData().get(MovementValidator.VALIDATE_MOVEMENT));
 		}
+	}
+
+	@CommandDescription(aliases = {"ver", "version"}, desc = "Display the version of Spout this server is running.")
+	@Permissible("spout.command.version")
+	public void version(CommandSource source, CommandArguments args) throws CommandException {
+		source.sendMessage("This server is running Spout #" + Spout.getAPIVersion().replace("dev b", "") + ".");
 	}
 }


### PR DESCRIPTION
- Adds /version (with /ver as an alias)
- Adds 'spout.command.version' permission to the 'version' command.
- Adds 'spout.command.batch' permission to the 'batch' command.
- Changes the server version output displayed on startup.

Signed-off-by: Steven Downer grinch@outlook.com
