### PR TITLE
Remove redundant chunk-coords passed into generate method

### DIFF
--- a/api/src/main/java/org/spout/api/generator/EmptyWorldGenerator.java
+++ b/api/src/main/java/org/spout/api/generator/EmptyWorldGenerator.java
@@ -36,7 +36,7 @@ import org.spout.api.util.cuboid.CuboidBlockMaterialBuffer;
  */
 public class EmptyWorldGenerator implements WorldGenerator {
 	@Override
-	public void generate(CuboidBlockMaterialBuffer blockData, int chunkX, int chunkY, int chunkZ, World world) {
+	public void generate(CuboidBlockMaterialBuffer blockData, World world) {
 		blockData.flood(BlockMaterial.AIR);
 	}
 

--- a/api/src/main/java/org/spout/api/generator/FlatWorldGenerator.java
+++ b/api/src/main/java/org/spout/api/generator/FlatWorldGenerator.java
@@ -36,8 +36,8 @@ import org.spout.api.util.cuboid.CuboidBlockMaterialBuffer;
  */
 public class FlatWorldGenerator implements WorldGenerator {
 	@Override
-	public void generate(CuboidBlockMaterialBuffer blockData, int chunkX, int chunkY, int chunkZ, World world) {
-		if (chunkY < 0) {
+	public void generate(CuboidBlockMaterialBuffer blockData, World world) {
+		if (blockData.getBase().getY() < 0) {
 			blockData.flood(BlockMaterial.SOLID_BLUE);
 		}
 	}

--- a/api/src/main/java/org/spout/api/generator/LayeredWorldGenerator.java
+++ b/api/src/main/java/org/spout/api/generator/LayeredWorldGenerator.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Chunk;
-import org.spout.api.geo.cuboid.Region;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.util.cuboid.CuboidBlockMaterialBuffer;
 
@@ -47,9 +46,9 @@ public class LayeredWorldGenerator implements WorldGenerator {
 	private short floorid = 0, floordata = 0;
 
 	@Override
-	public void generate(CuboidBlockMaterialBuffer blockData, int chunkX, int chunkY, int chunkZ, World world) {
-		final int startY = chunkY << Chunk.BLOCKS.BITS;
-		final int endY = startY + Region.BLOCKS.SIZE;
+	public void generate(CuboidBlockMaterialBuffer blockData, World world) {
+		final int startY = blockData.getBase().getFloorY();
+		final int endY = blockData.getTop().getFloorY();
 		int y, height;
 		for (Layer layer : this.layers) {
 			if (layer.getTop() > startY && layer.getY() < endY) {

--- a/api/src/main/java/org/spout/api/generator/WorldGenerator.java
+++ b/api/src/main/java/org/spout/api/generator/WorldGenerator.java
@@ -39,18 +39,16 @@ public interface WorldGenerator extends Named {
 	/**
 	 * Gets the block structure for a Chunk.
 	 *
-	 * The CuboidBuffer will always be:<br> - One Chunk in width and length {@link org.spout.api.geo.cuboid.Chunk#CHUNKS}<br> - One Region in height {@link org.spout.api.geo.cuboid.Region#CHUNKS}<br> -
-	 * Chunk aligned<br> <br> Structural blocks should not contain any lighting sources and the generator should give repeatable results.
+	 * The CuboidBuffer will always be chunk-aligned, and could be of a variable (chunk) size.<br><br>
+	 * Use {@link CuboidBlockMaterialBuffer#getBase()} and {@link CuboidBlockMaterialBuffer#getTop()}
+	 * to obtain the Block bounds in which can be generated.
 	 *
 	 * It is recommended that seeded random number generators from WorldGeneratorUtils are used.
 	 *
-	 * @param blockData a zeroed CuboidBuffer corresponding to the Chunk
-	 * @param chunkX coordinate
-	 * @param chunkY coordinate
-	 * @param chunkZ coordinate
+	 * @param blockData a zeroed CuboidBuffer which has to be fully generated
 	 * @param world in which is generated
 	 */
-	public void generate(CuboidBlockMaterialBuffer blockData, int chunkX, int chunkY, int chunkZ, World world);
+	public void generate(CuboidBlockMaterialBuffer blockData, World world);
 
 	/**
 	 * Gets the surface height of the world. This is used for initialisation purposed only, so only needs reasonable accuracy.<br> <br> The result value should be a 2d array of size {@link

--- a/api/src/main/java/org/spout/api/generator/biome/BiomeGenerator.java
+++ b/api/src/main/java/org/spout/api/generator/biome/BiomeGenerator.java
@@ -79,15 +79,15 @@ public abstract class BiomeGenerator implements WorldGenerator {
 	}
 
 	@Override
-	public void generate(CuboidBlockMaterialBuffer blockData, int chunkX, int chunkY, int chunkZ, World world) {
-		final int x = chunkX << Chunk.BLOCKS.BITS;
-		final int y = chunkY << Chunk.BLOCKS.BITS;
-		final int z = chunkZ << Chunk.BLOCKS.BITS;
+	public void generate(CuboidBlockMaterialBuffer blockData, World world) {
+		final int x = blockData.getBase().getFloorX();
+		final int y = blockData.getBase().getFloorY();
+		final int z = blockData.getBase().getFloorZ();
 		final BiomeManager manager;
 		if (blockData.getSize().getFloorX() <= Chunk.BLOCKS.SIZE && blockData.getSize().getFloorZ() <= Chunk.BLOCKS.SIZE) {
 			BiomeManager temp = world.getBiomeManager(x, z, LoadOption.NO_LOAD);
 			if (temp == null) {
-				temp = generateBiomes(chunkX, chunkZ, world);
+				temp = generateBiomes(blockData.getBaseChunkX(), blockData.getBaseChunkZ(), world);
 			}
 			manager = temp;
 		} else {
@@ -102,7 +102,7 @@ public abstract class BiomeGenerator implements WorldGenerator {
 			if (zSize % Chunk.BLOCKS.SIZE > 0) {
 				zChunkSize++;
 			}
-			manager = new WrappedBiomeManager(this, world, chunkX, chunkZ, xChunkSize, zChunkSize);
+			manager = new WrappedBiomeManager(this, world, blockData.getBaseChunkX(), blockData.getBaseChunkZ(), xChunkSize, zChunkSize);
 		}
 		final long seed = world.getSeed();
 		generateTerrain(blockData, x, y, z, manager, seed);

--- a/api/src/main/java/org/spout/api/util/cuboid/CuboidBuffer.java
+++ b/api/src/main/java/org/spout/api/util/cuboid/CuboidBuffer.java
@@ -26,6 +26,7 @@
  */
 package org.spout.api.util.cuboid;
 
+import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.math.Vector3;
 
 /**
@@ -55,6 +56,7 @@ public abstract class CuboidBuffer {
 	 * Note: These values are not actually within the cuboid The cuboid goes
 	 * from baseX to baseX + sizeX - 1 top = base + size
 	 */
+	protected final Vector3 top;
 	protected final int topX;
 	protected final int topY;
 	protected final int topZ;
@@ -75,9 +77,11 @@ public abstract class CuboidBuffer {
 
 		this.base = new Vector3(baseX, baseY, baseZ);
 
-		topX = baseX + sizeX;
-		topY = baseY + sizeY;
-		topZ = baseZ + sizeZ;
+		this.topX = baseX + sizeX;
+		this.topY = baseY + sizeY;
+		this.topZ = baseZ + sizeZ;
+
+		this.top = new Vector3(this.topX, this.topY, this.topZ);
 
 		Yinc = sizeZ * (Zinc = sizeX * (Xinc = 1));
 	}
@@ -98,6 +102,33 @@ public abstract class CuboidBuffer {
 	}
 
 	/**
+	 * Gets the X-coordinate of the chunk the base of this CuboidBuffer is in
+	 * 
+	 * @return base chunk X-coordinate
+	 */
+	public int getBaseChunkX() {
+		return baseX << Chunk.BLOCKS.BITS;
+	}
+
+	/**
+	 * Gets the Y-coordinate of the chunk the base of this CuboidBuffer is in
+	 * 
+	 * @return base chunk Y-coordinate
+	 */
+	public int getBaseChunkY() {
+		return baseY << Chunk.BLOCKS.BITS;
+	}
+
+	/**
+	 * Gets the Z-coordinate of the chunk the base of this CuboidBuffer is in
+	 * 
+	 * @return base chunk Z-coordinate
+	 */
+	public int getBaseChunkZ() {
+		return baseZ << Chunk.BLOCKS.BITS;
+	}
+
+	/**
 	 * Gets the size of the CuboidBuffer
 	 */
 	public Vector3 getSize() {
@@ -115,7 +146,7 @@ public abstract class CuboidBuffer {
 	 * Gets the top-coordinates of the CuboidBuffer, these are outside this buffer<br> These coordinates are an addition of base and size
 	 */
 	public Vector3 getTop() {
-		return new Vector3(topX, topY, topZ);
+		return top;
 	}
 
 	/**

--- a/engine/src/main/java/org/spout/engine/world/RegionGenerator.java
+++ b/engine/src/main/java/org/spout/engine/world/RegionGenerator.java
@@ -182,7 +182,7 @@ public class RegionGenerator implements Named {
 			int czz = cz + z;
 
 			final CuboidBlockMaterialBuffer buffer = new CuboidBlockMaterialBuffer(cxx << Chunk.BLOCKS.BITS, cy << Chunk.BLOCKS.BITS, czz << Chunk.BLOCKS.BITS, Chunk.BLOCKS.SIZE << shift, Region.BLOCKS.SIZE, Chunk.BLOCKS.SIZE << shift);
-			world.getGenerator().generate(buffer, cxx, cy, czz, world);
+			world.getGenerator().generate(buffer, world);
 
 			int[][] heights = new int[Chunk.BLOCKS.SIZE << shift][Chunk.BLOCKS.SIZE << shift];
 


### PR DESCRIPTION
You can access the base chunk coordinates in the buffer. This prevents people from confusing the generator for generating a single chunk at once, instead of multiple chunks like it does.

It's better to let people access the base point information in the buffer instead of passing it into the method, since the current buffer might be re-used (performance?) at some point in time. It is better to catch it right then than to find out that one method, that was using these coordinates (such as setHorizontalLayer) suddenly fails, leaving us clueless.

Plus, it reduces how complicated the generate method looks like.

Initially I also wanted to include a World and turn the top/base into a Point, but the cuboid buffer is meant to be used without a World (offline), so I decided not to take that route.

Note: requires vanilla changes as well, see https://github.com/Vanilla/Vanilla/pull/639

Signed-off-by: Irmo van den Berge bergerkiller@gmail.com
