### PR TITLE
Made DefaultedKeyFactory support all Class types

### DIFF
--- a/api/src/main/java/org/spout/api/map/DefaultedKeyFactory.java
+++ b/api/src/main/java/org/spout/api/map/DefaultedKeyFactory.java
@@ -32,9 +32,10 @@ public class DefaultedKeyFactory<T extends Serializable> implements DefaultedKey
 	private final Class<T> defaultValue;
 	private final String key;
 
-	public DefaultedKeyFactory(String key, Class<T> defaultValue) {
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public DefaultedKeyFactory(String key, Class<?> defaultValue) {
 		this.key = key;
-		this.defaultValue = defaultValue;
+		this.defaultValue = (Class) defaultValue;
 	}
 
 	@Override


### PR DESCRIPTION
This allows generic types to be constructed without a lot of hassle with warnings and unsafe casting.

Signed-off-by: Irmo van den Berge bergerkiller@gmail.com
