### PR TITLE
Add configuration for Server name. Adds SPOUT-33

### DIFF
--- a/api/src/main/java/org/spout/api/Server.java
+++ b/api/src/main/java/org/spout/api/Server.java
@@ -329,4 +329,10 @@ public interface Server extends Engine {
 	public File getWorldFolder();
 
 	public ServerSession newSession(Channel c);
+
+	/**
+	 * Gets the server's name
+	 * @return server name
+	 */
+	public String getName();
 }

--- a/engine/src/main/java/org/spout/engine/SpoutConfiguration.java
+++ b/engine/src/main/java/org/spout/engine/SpoutConfiguration.java
@@ -36,6 +36,7 @@ import org.spout.engine.filesystem.CommonFileSystem;
 
 public class SpoutConfiguration extends ConfigurationHolderConfiguration {
 	// General
+	public static final ConfigurationHolder SERVER_NAME = new ConfigurationHolder("A Spout Server", "general", "server-name");
 	public static final ConfigurationHolder MAXIMUM_PLAYERS = new ConfigurationHolder(20, "general", "maximum-players");
 	public static final ConfigurationHolder DEFAULT_WORLD = new ConfigurationHolder("world", "general", "default-world");
 	public static final ConfigurationHolder WHITELIST_ENABLED = new ConfigurationHolder(false, "general", "whitelist-enabled");

--- a/engine/src/main/java/org/spout/engine/SpoutEngine.java
+++ b/engine/src/main/java/org/spout/engine/SpoutEngine.java
@@ -242,11 +242,6 @@ public abstract class SpoutEngine implements AsyncManager, Engine {
 	}
 
 	@Override
-	public String getName() {
-		return "Spout Engine";
-	}
-
-	@Override
 	public String getVersion() {
 		return getClass().getPackage().getImplementationVersion();
 	}

--- a/engine/src/main/java/org/spout/engine/SpoutServer.java
+++ b/engine/src/main/java/org/spout/engine/SpoutServer.java
@@ -368,7 +368,7 @@ public class SpoutServer extends SpoutEngine implements Server {
 
 	@Override
 	public String getName() {
-		return "Spout Server";
+		return SpoutConfiguration.SERVER_NAME.getString();
 	}
 
 	private UpnpService getUPnPService() {


### PR DESCRIPTION
Abstrct class shouldn't define implementation specific names.
Added Server.getName() so Server objects don't need to be cast into engine objects.

Signed-off-by: Nick Minkler sleaker@gmail.com
