### PR TITLE
make mapHash return something other than 0

### DIFF
--- a/api/src/main/java/org/spout/api/util/map/concurrent/TSyncIntObjectHashMap.java
+++ b/api/src/main/java/org/spout/api/util/map/concurrent/TSyncIntObjectHashMap.java
@@ -416,7 +416,7 @@ public class TSyncIntObjectHashMap<V> implements TSyncIntObjectMap<V> {
 	}
 
 	private int mapHash(int key) {
-		int intKey = (key >> 32 ^ key);
+		int intKey = (key >> (32 ^ key));
 
 		return (0x7FFFFFFF & intKey) % hashScramble & mapMask;
 	}


### PR DESCRIPTION
as written

 int intKey = (key >> 32 ^ key);

creates 0, as shifting by 32 is the same as shifting by 0, then exclusive oring with self is 0. always 0.

Make the hash distributed, by adding parens

int intKey = (key >> (32 ^ key));
